### PR TITLE
feat(003): 同領域對手排名 tab (Closes #6)

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,7 @@ st.caption(
     f"共 {len(df):,} 筆 · 跨度 {date_span_days} 天"
 )
 
-tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8 = st.tabs(["市場", "趨勢", "競爭", "機關", "雷達", "對手查詢", "公司查詢", "清單"])
+tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8, tab9 = st.tabs(["市場", "趨勢", "競爭", "機關", "雷達", "對手查詢", "公司查詢", "清單", "同領域"])
 
 # ---------- 市場 ----------
 with tab1:
@@ -629,3 +629,60 @@ with tab8:
         use_container_width=True,
         column_config={"url": st.column_config.LinkColumn("連結")},
     )
+
+# ---------- 同領域對手排名 ----------
+with tab9:
+    st.subheader("同領域對手排名")
+    st.caption("輸入關鍵字（比對 title），看近 12 個月該領域誰是老大、自家排第幾")
+    kw9 = st.text_input("關鍵字", placeholder="例：圖書館、資安、AI、無障礙")
+    if kw9:
+        cutoff = pd.Timestamp.now().normalize() - pd.Timedelta(days=365)
+        pool = df[
+            df["type"].str.contains("決標", na=False)
+            & df["award_amount"].notna()
+            & df["companies"].notna()
+            & (df["date"] >= cutoff)
+            & df["title"].str.contains(kw9, na=False)
+        ].copy()
+        if len(pool):
+            pool["company"] = pool["companies"].str.split("|")
+            exp9 = pool.explode("company")
+            exp9["company"] = exp9["company"].str.strip()
+            exp9 = exp9[exp9["company"] != ""]
+
+            agg9 = exp9.groupby("company").agg(
+                案數=("job_number", "count"),
+                總金額=("award_amount", "sum"),
+            ).sort_values("總金額", ascending=False)
+            total_amt9 = agg9["總金額"].sum()
+            agg9["市占率(%)"] = (agg9["總金額"] / total_amt9 * 100).round(1) if total_amt9 else 0
+            agg9["金額(萬)"] = (agg9["總金額"] / 1e4).round(0).astype(int)
+            agg9["自家"] = agg9.index.to_series().apply(is_own)
+            agg9["排名"] = range(1, len(agg9) + 1)
+
+            c1, c2, c3 = st.columns(3)
+            c1.metric("命中案數", f"{len(pool):,}")
+            c2.metric("參與廠商數", f"{len(agg9):,}")
+            c3.metric("搜尋結果總金額（億）", f"{total_amt9 / 1e8:.2f}")
+
+            st.divider()
+            st.markdown(f"**Top 10（關鍵字：{kw9}｜近 12 個月）**")
+            top10 = agg9.head(10).reset_index()[["排名", "company", "案數", "金額(萬)", "市占率(%)", "自家"]]
+            top10 = top10.rename(columns={"company": "廠商"})
+            st.dataframe(top10, use_container_width=True, hide_index=True)
+
+            own9 = agg9[agg9["自家"]]
+            if len(own9):
+                not_in_top = own9[own9["排名"] > 10]
+                if len(not_in_top):
+                    lines = [
+                        f"- **{name}**：第 {int(row['排名'])} 名（案數 {int(row['案數'])}、金額 {int(row['金額(萬)']):,} 萬、市占 {row['市占率(%)']}%）"
+                        for name, row in not_in_top.iterrows()
+                    ]
+                    st.info("**我方排名（未進 Top 10）**\n" + "\n".join(lines))
+                else:
+                    st.success("自家已進 Top 10 ✅")
+            else:
+                st.warning(f"近 12 個月內「{kw9}」領域自家無得標紀錄")
+        else:
+            st.info(f"近 12 個月內無「{kw9}」相關決標案件")

--- a/stories/003-market-watch/features/competitor-ranking/SPEC.md
+++ b/stories/003-market-watch/features/competitor-ranking/SPEC.md
@@ -1,0 +1,41 @@
+# SPEC: 同領域對手排名（Competitor Ranking）
+
+> 新增於 2026-04-24（issue #6）。位置：`app.py` tab9「同領域」。
+
+## 1. Objective
+輸入關鍵字（例：「圖書館」「資安」「AI」），回答「這個領域近 12 個月誰是老大、自家排第幾」。
+
+**User**：總經理 / 策略主管，競爭格局情報。
+
+## 2. Commands
+`streamlit run app.py` → tab9「同領域」→ 輸入關鍵字。
+
+## 3. 輸入
+- 關鍵字文字框（必填）
+- 期間：固定近 12 個月（v1 不可調）
+
+## 4. 處理邏輯
+1. 過濾 `type 含「決標」 且 award_amount notna 且 companies notna`
+2. 只保留近 12 個月（`date >= today - 365d`）
+3. 對 `title` 做子字串比對（大小寫敏感，與既有 `count_themes` 一致）
+4. `companies` 以 `|` 拆分並 explode 成單一廠商列
+5. groupby company → 案數、總金額
+6. 市占率 = 廠商總金額 / 搜尋結果內總金額
+
+## 5. 輸出
+- **摘要 metrics**：命中案數、參與廠商數、搜尋結果總金額
+- **Top 10 表格**：排名 / 廠商 / 案數 / 總金額（萬）/ 市占率（%）/ 自家?
+- **自家補行**：若 `OWN_COMPANIES` 任一不在 Top 10，在表格下方顯示「我方排名：第 N 名（案數 X / 金額 Y 萬 / 市占 Z%）」；完全無命中則顯示警示。
+
+## 6. 資料要求
+欄位：`type`, `award_amount`, `companies`, `title`, `date`。
+
+## 7. Boundaries（v1 不做）
+- 跨年度趨勢 / YoY
+- 聯合承攬關係圖
+- 子公司合併計算（僅用 `OWN_COMPANIES` 字串比對，多筆匹配算不同廠商）
+- 關鍵字 AND/OR 組合（單一關鍵字子字串）
+
+## 8. 設計註記
+- **自家公司設定**：沿用 `helpers.OWN_COMPANIES`，不新增常數。
+- **與 tab3「競爭」差異**：tab3 是全市場 Top 20，本 tab 是「領域過濾」的 Top 10。


### PR DESCRIPTION
Closes #6

## Summary
新增 tab9「同領域」，輸入關鍵字即看近 12 個月該領域廠商排名，回答「誰是老大、自家排第幾」。

## 變更
- `app.py`：tabs list 新增「同領域」；新 tab9 區塊（約 60 行）
- `stories/003-market-watch/features/competitor-ranking/SPEC.md`：新 SPEC

## 邏輯
1. 過濾 `決標 + award_amount notna + companies notna + date ≥ 365 天前 + title 含關鍵字`
2. `companies` 拆 `|` explode
3. groupby 廠商 → 案數 / 總金額 / 市占率（分母 = 搜尋結果總金額）
4. Top 10；自家未進榜 → 補行顯示「我方排名第 N」

## 設計取捨
- 自家公司沿用現有 `helpers.OWN_COMPANIES`（issue 原本要求「加設定常數」但既有常數已滿足）
- 與 tab3「競爭」差異：tab3 全市場 Top 20；tab9 關鍵字過濾 Top 10

## Test plan
- [x] `pytest` 13 passed
- [x] Syntax OK
- [x] Smoke test（關鍵字「圖書館」）：18 案命中，凌網知識 23.7% 市占第 1、凌網資訊第 4
- [x] UI 本機驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)