### PR TITLE
[黃仁勳] P0 標案 watcher → Slack 推播（loop pilot, issue #14）

### DIFF
--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   watch:
     runs-on: ubuntu-latest
-    timeout-minutes: 10        # 硬時間封頂：超時 CI 自動 kill（呼應 watcher TIME_CAP）
+    timeout-minutes: 10        # job 級硬時間封頂；watcher step 另設 5 分鐘細粒度封頂
     permissions:
       contents: write
     steps:
@@ -54,13 +54,17 @@ jobs:
         run: python scripts/merge.py --weekly data/weekly.csv --master data/bids.csv
 
       - name: P0 watcher (diff → P0 → 封頂 → Slack)
+        # 時間封頂在此 step 硬 kill（取代 watcher.py 已移除的軟檢查；ADR D4）。
+        # diff/P0 純記憶體操作極快，5 分鐘足夠；超時即 fail 喊人。
+        timeout-minutes: 5
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           PUSH="${{ github.event.inputs.push || 'false' }}"
           ARGS="--weekly data/weekly.csv --state data/watcher_state.json"
           if [ "$PUSH" = "true" ]; then ARGS="$ARGS --push"; fi
-          # watcher capped/timeout 回 exit 2 → 標記但不讓整個 job 失敗（降級是正常路徑）
+          # watcher capped 回 exit 2 → 標記但不讓整個 job 失敗（降級是正常路徑；
+          # 時間封頂改靠本 step timeout-minutes 硬 kill，不再經 exit 2）
           python scripts/watcher.py $ARGS || ec=$?
           if [ "${ec:-0}" = "2" ]; then
             echo "::warning::watcher 觸發成本封頂/超時降級（見 data/alerts/）"

--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -1,0 +1,78 @@
+name: Daily P0 watcher (pcc-tender → Slack)
+
+# loop engineering pilot（issue #14）：每日 fetch → merge → P0 watcher → Slack 推播。
+#
+# ⚠️ 啟用前置（人類動作，pilot 期留 Jay）：
+#   1. repo Settings → Secrets → Actions 新增：
+#        TWINKLE_API_KEY = sk-xxxx
+#        SLACK_WEBHOOK_URL = https://hooks.slack.com/...   ← Jay 設，確認 payload 格式後才填
+#   2. 確認 dry-run dispatch 跑通、payload 格式 OK 後，
+#      才把 watcher step 的 --push 打開 + 取消 schedule 註解。
+#
+# schedule 預設「註解停用」：先 workflow_dispatch 手動驗。
+# Slack 預設 dry-run（不傳 --push）→ 只印 payload 不推真頻道，符合 #14 checkpoint。
+
+on:
+  # schedule:
+  #   - cron: "0 0 * * *"   # 每日 08:00 台北（dispatch 驗證 + Jay 設 webhook 後啟用）
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "抓取天數（預設 2；每日跑只需近 2 天確保重疊）"
+        default: "2"
+      push:
+        description: "實際推 Slack？（true=推，預設 false=dry-run）"
+        default: "false"
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10        # 硬時間封頂：超時 CI 自動 kill（呼應 watcher TIME_CAP）
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - run: pip install -r requirements.txt
+
+      - name: Fetch (pcc-tender)
+        env:
+          TWINKLE_API_KEY: ${{ secrets.TWINKLE_API_KEY }}
+        run: |
+          if [ -z "$TWINKLE_API_KEY" ]; then
+            echo "::error::缺 secret TWINKLE_API_KEY"; exit 1
+          fi
+          DAYS="${{ github.event.inputs.days || '2' }}"
+          python scripts/fetch_pcc.py --days "$DAYS" --out data/weekly.csv
+
+      - name: Merge to master
+        run: python scripts/merge.py --weekly data/weekly.csv --master data/bids.csv
+
+      - name: P0 watcher (diff → P0 → 封頂 → Slack)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          PUSH="${{ github.event.inputs.push || 'false' }}"
+          ARGS="--weekly data/weekly.csv --state data/watcher_state.json"
+          if [ "$PUSH" = "true" ]; then ARGS="$ARGS --push"; fi
+          # watcher capped/timeout 回 exit 2 → 標記但不讓整個 job 失敗（降級是正常路徑）
+          python scripts/watcher.py $ARGS || ec=$?
+          if [ "${ec:-0}" = "2" ]; then
+            echo "::warning::watcher 觸發成本封頂/超時降級（見 data/alerts/）"
+          elif [ "${ec:-0}" != "0" ]; then
+            exit "$ec"
+          fi
+
+      - name: Commit state + master + alerts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/bids.csv data/watcher_state.json data/alerts 2>/dev/null || true
+          git diff --cached --quiet || \
+            git commit -m "watcher: daily run $(date -u +%Y-%m-%dT%H:%M) (state+runlog)"
+          git push

--- a/docs/adr/0001-p0-watcher-loop-pilot.md
+++ b/docs/adr/0001-p0-watcher-loop-pilot.md
@@ -1,0 +1,73 @@
+# ADR 0001 — P0 標案 watcher loop pilot 架構決策
+
+- 狀態：Proposed（待 Jay/RD review，PR #issue-14）
+- 日期：2026-06-13
+- 脈絡：issue #14（loop engineering 首個常駐 loop pilot）
+
+## 背景
+
+在 gov-bid-watch 既有 fetch→merge 管線末端加「P0 標案 watcher → Slack 推播」。
+真交付物是 **observability + 成本封頂** 的工程實踐，標案推播只是載體。
+SDD 已由 Jay + 馬斯克定案，本 ADR 記實作期拍板的架構決策供 reviewer 跟上推理鏈。
+
+## 決策
+
+### D1. P0 evaluator 純布林、零 LLM（pilot 鐵則）
+
+`is_p0(row) = NOT 排除詞命中 AND (機關白名單命中 OR P0 關鍵字命中)`。
+
+- 為何：loop 的 evaluator 必須錨在**非 LLM 客觀信號**，才能可重複、可審、零成本。LLM 判「值不值得投」留未來，pilot 不碰。
+- 反方：布林規則會誤報（如「整合/維護」泛詞）。取捨：pilot 期**寬鬆寧可誤報**（brief），run-log 記足以事後收緊；誤報不設硬上限，靠成本封頂擋爆量。
+- 反悔成本：低。規則集中在 `scripts/p0_rules.py`，加 LLM 層只是在布林之後串一段，不動既有管線。
+
+### D2. 複用既有 KEYWORDS/BLACKLIST，P0 只加「加強層」（單一事實源）
+
+既有 `fetch_bids.py` 的字典負責「是不是軟體類」；`p0_rules.py` 只定義既有沒有的
+機關白名單 + P0 專屬詞（借閱/無障礙/監視系統排除等），重疊詞不重抄。
+
+- 為何：兩份平行字典必然 drift。brief 明確要求單一事實源。
+- 反方：分層後讀者需看兩檔才知完整字典。取捨：在 p0_rules docstring 註明分層，可接受。
+
+### D3. diff 用獨立水位 state，不改 merge.py
+
+`merge.py` 只去重合併進 master、不輸出 new rows（既有行為不動）。新增
+`scripts/watcher_diff.py` 維護 `data/watcher_state.json`（seen key 水位 + run-log），
+key 沿用 merge 主鍵 `(unit_id, job_number, date)`。
+
+- 為何：merge 是資料層、watcher 是通知層，職責分離。改 merge 輸出 new rows 會牽動既有 weekly.yml commit 流程，風險高於另開模組。
+- 反方：兩處各記一份「見過什麼」。取捨：key 定義共用同一主鍵函數對齊，drift 風險可控。
+- 反悔成本：中。若日後要合併，把 watcher_diff 的 key 邏輯回收進 merge 即可。
+
+### D4. 成本封頂 = loop 終止/降級錨點
+
+單輪 P0 候選 > 20 → **不推、寫 alert**（`data/alerts/`）+ 水位仍前進避免下輪重複爆量；
+單輪 > 5 分鐘 → alert（硬 kill 靠 CI step timeout）。
+
+- 為何：loop 最大風險是「規則錯/資料異常 → 轟爆 Slack」。封頂讓 loop 在失控時**停下喊人**而非繼續輸出。這是 pilot 要驗的兩個工程真空之一。
+- 反方：>20 真的有 20 個 P0 時會被誤擋。取捨：pilot 階段「停下喊人」優於「誤轟」；閾值可調（`--push-cap`）。
+- 中止演練（`drill_abort.py`）= 回退水位人造爆量，驗證封頂確實觸發，可重複執行。
+
+### D5. Slack 停在 dry-run（checkpoint，issue #14 §7）
+
+推播函數讀 env `SLACK_WEBHOOK_URL`，預設 dry-run 印 payload。**不建 webhook、不推真頻道**。
+
+- 為何：外部系統設定 = 對外動作，留 Jay。實際 webhook URL 由 Jay 設 repo secret，確認 payload 格式後才接真 Slack。
+- 反悔成本：零。`notify(dry_run=False)` 一個 flag 即切真推。
+
+### D6. 頻率每日 1 次、cron 預設停用
+
+新增 daily workflow，schedule 預設註解停用，靠 workflow_dispatch 手動驗證；
+sequence：fetch → merge → watcher（dry-run）→ commit state/run-log。
+
+- 為何：沿用既有 weekly.yml「先手動 dispatch 驗證再啟自動」紀律。pilot 不自啟正式 schedule（brief 鐵則）。
+
+## 觀測（observability）
+
+每輪寫 run-log 進 `watcher_state.json.runs`：時間 / fetched / new / pushed / watermark / note。
+誤報數可由 run-log + 人工標註事後算，供 7 天後收緊規則。alert 落 `data/alerts/` 可查。
+
+## 未採用
+
+- LLM 判標案價值（schema 填充率不足 + pilot 鐵則禁）
+- 真得標率分析、金額/截止日維度（pcc 招標公告無結構化欄位）
+- 改 merge.py 輸出 new rows（風險見 D3）

--- a/docs/adr/0001-p0-watcher-loop-pilot.md
+++ b/docs/adr/0001-p0-watcher-loop-pilot.md
@@ -40,11 +40,13 @@ key 沿用 merge 主鍵 `(unit_id, job_number, date)`。
 
 ### D4. 成本封頂 = loop 終止/降級錨點
 
-單輪 P0 候選 > 20 → **不推、寫 alert**（`data/alerts/`）+ 水位仍前進避免下輪重複爆量；
-單輪 > 5 分鐘 → alert（硬 kill 靠 CI step timeout）。
+單輪 P0 候選 > 20 → **不推、寫 alert**（`data/alerts/`，alert 含被擋 P0 完整清單供人工補救）+ 水位仍前進避免下輪重複爆量；
+時間封頂 → **由 CI step `timeout-minutes: 5` 硬 kill**，watcher.py 不做軟檢查。
 
 - 為何：loop 最大風險是「規則錯/資料異常 → 轟爆 Slack」。封頂讓 loop 在失控時**停下喊人**而非繼續輸出。這是 pilot 要驗的兩個工程真空之一。
-- 反方：>20 真的有 20 個 P0 時會被誤擋。取捨：pilot 階段「停下喊人」優於「誤轟」；閾值可調（`--push-cap`）。
+- 時間封頂為何移到 CI：watcher 內 diff/P0 是純記憶體操作，跑不到 300s，真正慢的 fetch 在 watcher 之外（另一 step），檔內軟檢查永遠觸發不到 = 擺設。硬 kill 交給 CI `timeout-minutes` 才真正生效。
+- 0 漏報修正：capped 後水位前進，被擋 P0 下輪不再被 `find_new` 看到 → alert 必須記完整被擋清單（title/unit_name/job_number），否則靜默漏報。
+- 反方：>20 真的有 20 個 P0 時會被誤擋。取捨：pilot 階段「停下喊人」優於「誤轟」；閾值可調（`--push-cap`），且被擋清單已留存可補救。
 - 中止演練（`drill_abort.py`）= 回退水位人造爆量，驗證封頂確實觸發，可重複執行。
 
 ### D5. Slack 停在 dry-run（checkpoint，issue #14 §7）

--- a/scripts/audit_recall.py
+++ b/scripts/audit_recall.py
@@ -1,0 +1,65 @@
+"""0 漏報對照腳本（brief §4 驗收）— 可重複跑。
+
+驗證「命中 P0 規則的標案是否全推了」：
+- 對一份 ground-truth CSV（人工同期 query 的全集，或 weekly fetch 結果）套 is_p0，
+  得「應推集合」（key set）。
+- 對 watcher_state.json 的 run-log + 水位推導「實際處理/推播集合」。
+- 漏報 = 應推但不在已見/已推水位裡。回傳漏報清單；空 = 0 漏報。
+
+注意：watcher 水位記的是「已見 key」（commit_watermark 收全部 fetch），
+推播與否另看 run-log。本腳本的 recall 定義 = 應推 P0 是否都被 watcher 見過
+且在 dry-run 下會被推（capped 輪除外，capped 是主動降級非漏報）。
+
+用法：
+    python scripts/audit_recall.py --truth data/weekly.csv --state data/watcher_state.json
+退出碼 0 = 0 漏報；1 = 有漏報（印清單）。
+"""
+import argparse
+import csv
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from p0_rules import is_p0  # noqa: E402
+from watcher_diff import row_key  # noqa: E402
+
+
+def load_truth_p0(truth_csv: str):
+    with open(truth_csv, encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    p0 = [r for r in rows if is_p0(r)]
+    return {row_key(r): r for r in p0}
+
+
+def audit(truth_csv: str, state_path: str):
+    truth = load_truth_p0(truth_csv)
+    if not os.path.exists(state_path):
+        # 水位不存在 = 還沒跑過 → 全部視為漏報（提示先跑 watcher）
+        return list(truth.values()), len(truth)
+    state = json.load(open(state_path, encoding="utf-8"))
+    seen = set(state.get("seen_keys", []))
+    missed = [r for k, r in truth.items() if k not in seen]
+    return missed, len(truth)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--truth", default="data/weekly.csv",
+                    help="ground-truth 全集 CSV（人工同期 query 或 fetch 結果）")
+    ap.add_argument("--state", default="data/watcher_state.json")
+    args = ap.parse_args()
+
+    missed, total = audit(args.truth, args.state)
+    recall = (total - len(missed)) / total if total else 1.0
+    print(f"P0 應推 {total} 筆 ｜ 漏報 {len(missed)} 筆 ｜ recall {recall:.1%}",
+          file=sys.stderr)
+    for r in missed:
+        print(f"  ✗ 漏報 {row_key(r)} | {r.get('unit_name','')} | {r.get('title','')}",
+              file=sys.stderr)
+    sys.exit(0 if not missed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/drill_abort.py
+++ b/scripts/drill_abort.py
@@ -1,0 +1,90 @@
+"""跑偏中止演練 — 可重複執行，驗證成本封頂降級 alert（brief §4 驗收）。
+
+劇本（不碰真 Slack、不依賴外部 API）：
+1. 用合成資料建立水位（模擬已穩定運行的 watcher）。
+2. 故意把水位回退（rollback_watermark）→ 大量舊案重新被當「新出現」。
+3. 跑 watcher.run → P0 新出現數爆量 > push_cap → 應 status='capped'、寫 alert、pushed=0。
+4. 斷言：Slack 沒被轟（dry-run 下 pushed=0 且 status=capped）+ alert 檔存在。
+
+成功 = 演練回傳 0 + 印「DRILL PASSED」。失敗 = 非零退出。
+這支腳本本身就是「中止演練 1 次成功且可重複」的驗收載體（CI 可跑）。
+"""
+import csv
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import watcher  # noqa: E402
+from watcher_diff import (  # noqa: E402
+    commit_watermark,
+    load_state,
+    rollback_watermark,
+    save_state,
+)
+
+N = 30          # 合成軟體類 P0 標案數（> push_cap 才能觸發封頂）
+PUSH_CAP = 20
+
+
+def _p0_rows(n):
+    return [{
+        "unit_id": f"U{i}", "job_number": f"J{i}", "date": "20260613",
+        "title": "圖書館資訊系統建置案", "unit_name": "國立臺灣圖書館",
+        "type": "公開招標", "url": "http://example/x",
+    } for i in range(n)]
+
+
+def _write_csv(path, rows):
+    cols = ["unit_id", "job_number", "date", "title", "unit_name", "type", "url"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def run_drill():
+    tmp = tempfile.mkdtemp(prefix="watcher_drill_")
+    csvp = os.path.join(tmp, "weekly.csv")
+    statep = os.path.join(tmp, "state.json")
+    # alert 落到演練暫存區，不污染 repo data/alerts
+    orig_alert_dir = watcher.ALERT_DIR
+    watcher.ALERT_DIR = os.path.join(tmp, "alerts")
+
+    rows = _p0_rows(N)
+    _write_csv(csvp, rows)
+
+    try:
+        # 1. 建穩定水位：先跑一輪把全部收進水位（dry-run）
+        watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+        st = load_state(statep)
+        baseline_run = watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+        assert baseline_run["new"] == 0, "穩定態應 0 新出現"
+
+        # 2. 跑偏：回退水位（刪掉全部 seen → 舊案重新變新）
+        st = load_state(statep)
+        removed = rollback_watermark(st, len(st["seen_keys"]))
+        save_state(st, statep)
+        print(f"[drill] 水位回退 {removed} 筆（模擬跑偏/資料異常）", file=sys.stderr)
+
+        # 3. 再跑一輪 → 應觸發封頂
+        res = watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+
+        # 4. 斷言
+        assert res["status"] == "capped", f"應觸發封頂，實得 {res['status']}"
+        assert res["pushed"] == 0, f"Slack 不該被轟，pushed={res['pushed']}"
+        assert res["alert"] and os.path.exists(res["alert"]), "應寫 alert 檔"
+        alert = json.loads(open(res["alert"], encoding="utf-8").read())
+        assert alert["kind"] == "push_cap_exceeded"
+        print(f"[drill] 觸發封頂：p0={res['p0']} > cap={PUSH_CAP}，"
+              f"pushed={res['pushed']}，alert={alert['kind']}", file=sys.stderr)
+        print("DRILL PASSED ✅ — 跑偏 → 封頂 → alert，Slack 未被轟", file=sys.stderr)
+        return 0
+    finally:
+        watcher.ALERT_DIR = orig_alert_dir
+
+
+if __name__ == "__main__":
+    sys.exit(run_drill())

--- a/scripts/p0_rules.py
+++ b/scripts/p0_rules.py
@@ -1,0 +1,83 @@
+"""P0 標案判定規則 — 純布林、零 LLM（pilot 鐵則）。
+
+evaluator 錨在非 LLM 客觀信號：字串比對（機關白名單 OR 關鍵字）+ 既有軟體類粗篩。
+P0(row) 為真 = 軟體類候選（既有 pre_filter 通過）
+                AND (機關命中白名單 OR title 命中 P0 強/中關鍵字)
+                AND title 不命中 P0 排除詞。
+
+字典分層（單一事實源紀律）：
+- 既有 KEYWORDS/BLACKLIST（fetch_bids.py）負責「是不是軟體類候選」的粗篩，**複用不重抄**。
+- 本檔只定義「P0 加強層」：既有字典之上新增的機關白名單 + P0 專屬關鍵字/排除詞。
+  與既有字典重疊的詞不在此重複列出（重疊由 pre_filter 已涵蓋）。
+"""
+from fetch_bids import BLACKLIST, KEYWORDS, pre_filter  # noqa: F401  複用既有字典（單一事實源）
+
+# --- P0 機關白名單（§brief，pilot 期寬鬆，agency 子字串命中即算）---
+P0_AGENCIES = [
+    # 核心（做過/在做）
+    "圖書館", "國立臺灣圖書館", "移民署", "法務部", "立法院",
+    "數位發展部", "關務署", "中央銀行", "台灣中油", "臺灣中油",
+    # 戰略目標
+    "公共工程委員會", "審計部", "廉政署", "國家發展委員會", "政風",
+    # 廣撒觀察
+    "經濟部", "內政部", "教育部", "文化部", "交通部",
+    "勞動部", "衛生福利部", "衛福部", "農業部",
+]
+
+# --- P0 加強關鍵字（既有 KEYWORDS 之外的補充；title 子字串命中）---
+# 重疊既有 KEYWORDS 的詞（系統/軟體/資訊/網站/App/平台/數位/資料庫/雲端/AI/
+# 人工智慧/網路…）不重列，由 pre_filter 已涵蓋。此處只補既有沒有的。
+P0_KEYWORDS_EXTRA = [
+    # 強信號補充
+    "圖書館", "借閱", "無障礙", "WCAG", "開放資料", "行動", "入口網",
+    "系統開發", "系統建置",
+    # 中信號補充
+    "API", "資料視覺化", "整合", "委外", "維護",
+]
+
+# --- P0 排除詞（避免誤中非軟體勞務；既有 BLACKLIST 已含工程類，此處補勞務雜項）---
+P0_EXCLUDE_EXTRA = [
+    "監視系統", "門禁", "清潔", "保全", "印刷", "翻譯",
+]
+
+
+def hit_agency(agency: str) -> bool:
+    """機關白名單命中（子字串）。"""
+    if not agency:
+        return False
+    return any(a in agency for a in P0_AGENCIES)
+
+
+def hit_keyword(title: str) -> bool:
+    """P0 關鍵字命中：既有 KEYWORDS 任一 OR P0 加強關鍵字任一。"""
+    if not title:
+        return False
+    if any(k in title for k in KEYWORDS):
+        return True
+    return any(k in title for k in P0_KEYWORDS_EXTRA)
+
+
+def hit_exclude(title: str) -> bool:
+    """P0 排除詞命中（既有 BLACKLIST OR P0 排除補充）。命中即否決。"""
+    if not title:
+        return False
+    if any(b in title for b in BLACKLIST):
+        return True
+    return any(e in title for e in P0_EXCLUDE_EXTRA)
+
+
+def is_p0(row: dict) -> bool:
+    """純布林 P0 判定。row 需含 'title' 與 'unit_name'（agency）。
+
+    規則：
+      1. 排除詞命中 → 否決（優先級最高）
+      2. (機關白名單命中 OR P0 關鍵字命中) → P0
+    注意：不在此重跑 pre_filter — 上游 fetch_pcc 已做軟體類粗篩，
+    本 evaluator 只在候選集合上加 P0 升級判定。但若直接餵原始 row，
+    呼叫端應自行確保已過軟體類粗篩；本函數仍以排除詞守最後一道。
+    """
+    title = (row.get("title") or "").strip()
+    agency = (row.get("unit_name") or row.get("agency") or "").strip()
+    if hit_exclude(title):
+        return False
+    return hit_agency(agency) or hit_keyword(title)

--- a/scripts/slack_notify.py
+++ b/scripts/slack_notify.py
@@ -1,0 +1,58 @@
+"""Slack 推播 — 讀 env SLACK_WEBHOOK_URL，預設 dry-run（不實際推）。
+
+checkpoint（issue #14 §7）：實作到「讀 env + dry-run 驗證 payload」即停。
+**不實際建 webhook、不推真頻道**。實際 webhook URL 由 Jay 設 repo secret，
+確認推播格式後才接真 Slack。
+
+啟用真推：呼叫端傳 dry_run=False 且 env 有 SLACK_WEBHOOK_URL。
+"""
+import json
+import os
+import sys
+
+import requests
+
+
+def build_payload(rows: list) -> dict:
+    """P0 標案列 → Slack message payload（Block Kit）。"""
+    n = len(rows)
+    blocks = [{
+        "type": "header",
+        "text": {"type": "plain_text", "text": f"🎯 P0 標案 {n} 則"},
+    }]
+    for r in rows[:50]:  # Slack block 上限保護
+        title = r.get("title") or "(無標題)"
+        agency = r.get("unit_name") or r.get("agency") or ""
+        date = r.get("date") or ""
+        url = r.get("url") or ""
+        atype = r.get("type") or ""
+        line = f"*<{url}|{title}>*\n{agency} ｜ {atype} ｜ {date}" if url else \
+               f"*{title}*\n{agency} ｜ {atype} ｜ {date}"
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": line}})
+    text = f"P0 標案 {n} 則：" + "；".join(
+        (r.get("title") or "") for r in rows[:5]
+    )
+    return {"text": text, "blocks": blocks}
+
+
+def notify(rows: list, dry_run: bool = True, webhook: str = None) -> dict:
+    """推播 P0 列。回傳 {sent, dry_run, count, reason}。
+
+    dry_run=True（預設）→ 印 payload 不發送。
+    dry_run=False 但無 webhook → 不發送、reason='no_webhook'（不報錯，安全降級）。
+    """
+    payload = build_payload(rows)
+    webhook = webhook or os.environ.get("SLACK_WEBHOOK_URL", "")
+
+    if dry_run:
+        print("[slack dry-run] payload:", file=sys.stderr)
+        print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr)
+        return {"sent": False, "dry_run": True, "count": len(rows), "reason": "dry_run"}
+
+    if not webhook:
+        print("[slack] 無 SLACK_WEBHOOK_URL → 不推送（安全降級）", file=sys.stderr)
+        return {"sent": False, "dry_run": False, "count": len(rows), "reason": "no_webhook"}
+
+    resp = requests.post(webhook, json=payload, timeout=30)
+    resp.raise_for_status()
+    return {"sent": True, "dry_run": False, "count": len(rows), "reason": "ok"}

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -1,0 +1,127 @@
+"""P0 標案 watcher 主流程 — loop engineering pilot 的常駐 loop。
+
+管線：fetch（weekly.csv 或既有 fetch_pcc）→ diff（水位找新出現）→ P0 過濾
+      → 成本封頂檢查 → Slack 推播（dry-run）→ 更新水位 + run-log。
+
+成本封頂（brief §4，loop 終止/降級錨點）：
+- 單輪 P0 推播候選 > PUSH_CAP(20) → 判定規則錯/資料異常 → **不推、寫 alert**。
+- 單輪耗時 > TIME_CAP_SEC(300) → kill + alert（由呼叫端/CI timeout 或本檔軟檢查）。
+
+evaluator 全程零 LLM：diff 用字串 key、P0 用布林規則。
+Slack 停在 dry-run（checkpoint #14 §7）。
+"""
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from p0_rules import is_p0  # noqa: E402
+from slack_notify import notify  # noqa: E402
+from watcher_diff import (  # noqa: E402
+    append_runlog,
+    commit_watermark,
+    find_new,
+    load_state,
+    save_state,
+)
+
+PUSH_CAP = 20          # 單輪推播上限，超過 → 降級 alert 不推
+TIME_CAP_SEC = 300     # 單輪耗時上限（5 分鐘）
+ALERT_DIR = "data/alerts"
+
+
+def write_alert(kind: str, detail: dict) -> str:
+    os.makedirs(ALERT_DIR, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+    path = os.path.join(ALERT_DIR, f"{ts}-{kind}.json")
+    payload = {"ts": datetime.now().isoformat(timespec="seconds"),
+               "kind": kind, **detail}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    print(f"::warning::[alert:{kind}] {detail} -> {path}", file=sys.stderr)
+    return path
+
+
+def read_rows(csv_path: str) -> list:
+    with open(csv_path, encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def run(weekly_csv: str, state_path: str, dry_run: bool = True,
+        push_cap: int = PUSH_CAP, time_cap: int = TIME_CAP_SEC) -> dict:
+    """跑一輪 watcher。回傳結果 dict（含 status: ok|capped|timeout）。"""
+    t0 = time.time()
+    state = load_state(state_path)
+    rows = read_rows(weekly_csv)
+
+    # 1. diff：水位找新出現
+    new_rows = find_new(rows, state)
+    # 2. P0 布林過濾
+    p0_rows = [r for r in new_rows if is_p0(r)]
+
+    result = {"fetched": len(rows), "new": len(new_rows),
+              "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None}
+
+    # 3. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
+    if len(p0_rows) > push_cap:
+        alert = write_alert("push_cap_exceeded", {
+            "p0_count": len(p0_rows), "cap": push_cap,
+            "hint": "可能規則過鬆或水位回退/資料異常，停下檢查，未推 Slack",
+        })
+        result.update(status="capped", alert=alert)
+        # 水位仍前進（避免下輪重複爆量），但不推播
+        commit_watermark(rows, state)
+        append_runlog(state, fetched=len(rows), new=len(new_rows),
+                      pushed=0, note=f"CAPPED p0={len(p0_rows)}>{push_cap}")
+        save_state(state, state_path)
+        return result
+
+    # 4. 時間封頂（軟檢查；硬 kill 靠 CI step timeout）
+    if time.time() - t0 > time_cap:
+        alert = write_alert("time_cap_exceeded",
+                            {"elapsed": round(time.time() - t0, 1), "cap": time_cap})
+        result.update(status="timeout", alert=alert)
+        append_runlog(state, fetched=len(rows), new=len(new_rows),
+                      pushed=0, note="TIMEOUT")
+        save_state(state, state_path)
+        return result
+
+    # 5. 推播（dry-run 預設）
+    push_res = notify(p0_rows, dry_run=dry_run) if p0_rows else \
+        {"sent": False, "count": 0, "reason": "no_p0"}
+    result["pushed"] = len(p0_rows) if (push_res.get("sent") or dry_run) else 0
+    result["push_reason"] = push_res.get("reason")
+
+    # 6. 更新水位 + run-log
+    commit_watermark(rows, state)
+    append_runlog(state, fetched=len(rows), new=len(new_rows),
+                  pushed=result["pushed"],
+                  note=f"dry_run={dry_run} p0={len(p0_rows)}")
+    save_state(state, state_path)
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--weekly", default="data/weekly.csv", help="本輪 fetch 結果 CSV")
+    ap.add_argument("--state", default="data/watcher_state.json")
+    ap.add_argument("--push", action="store_true",
+                    help="實際推 Slack（預設 dry-run；需 env SLACK_WEBHOOK_URL）")
+    ap.add_argument("--push-cap", type=int, default=PUSH_CAP)
+    args = ap.parse_args()
+
+    res = run(args.weekly, args.state, dry_run=not args.push,
+              push_cap=args.push_cap)
+    print(json.dumps(res, ensure_ascii=False), file=sys.stderr)
+    # capped/timeout 用非零退出碼讓 CI 標紅（但不算 fetch 失敗）
+    if res["status"] in ("capped", "timeout"):
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -4,8 +4,9 @@
       → 成本封頂檢查 → Slack 推播（dry-run）→ 更新水位 + run-log。
 
 成本封頂（brief §4，loop 終止/降級錨點）：
-- 單輪 P0 推播候選 > PUSH_CAP(20) → 判定規則錯/資料異常 → **不推、寫 alert**。
-- 單輪耗時 > TIME_CAP_SEC(300) → kill + alert（由呼叫端/CI timeout 或本檔軟檢查）。
+- 單輪 P0 推播候選 > PUSH_CAP(20) → 判定規則錯/資料異常 → **不推、寫 alert**
+  （alert 含被擋 P0 完整清單，供人工補救；issue #14 §4 0 漏報）。
+- 時間封頂由 CI step `timeout-minutes` 硬 kill（本檔不做軟檢查，純記憶體操作跑不到上限）。
 
 evaluator 全程零 LLM：diff 用字串 key、P0 用布林規則。
 Slack 停在 dry-run（checkpoint #14 §7）。
@@ -15,7 +16,6 @@ import csv
 import json
 import os
 import sys
-import time
 from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -31,7 +31,6 @@ from watcher_diff import (  # noqa: E402
 )
 
 PUSH_CAP = 20          # 單輪推播上限，超過 → 降級 alert 不推
-TIME_CAP_SEC = 300     # 單輪耗時上限（5 分鐘）
 ALERT_DIR = "data/alerts"
 
 
@@ -53,9 +52,12 @@ def read_rows(csv_path: str) -> list:
 
 
 def run(weekly_csv: str, state_path: str, dry_run: bool = True,
-        push_cap: int = PUSH_CAP, time_cap: int = TIME_CAP_SEC) -> dict:
-    """跑一輪 watcher。回傳結果 dict（含 status: ok|capped|timeout）。"""
-    t0 = time.time()
+        push_cap: int = PUSH_CAP) -> dict:
+    """跑一輪 watcher。回傳結果 dict（含 status: ok|capped）。
+
+    時間封頂改由 CI step `timeout-minutes` 硬 kill（見 daily-watcher.yml），
+    本檔不做軟檢查（純記憶體操作跑不到 300s，軟檢查是擺設；ADR D4）。
+    """
     state = load_state(state_path)
     rows = read_rows(weekly_csv)
 
@@ -68,26 +70,23 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
               "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None}
 
     # 3. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
+    #    ⚠️ 0 漏報鐵則（issue #14 §4）：capped 時水位仍前進，被擋的 P0 下輪
+    #    不會再被 find_new 看到。因此 alert 必須完整記錄被擋清單，讓人能手動補救。
     if len(p0_rows) > push_cap:
+        blocked = [{"title": r.get("title", ""),
+                    "unit_name": r.get("unit_name", ""),
+                    "job_number": r.get("job_number", "")}
+                   for r in p0_rows]
         alert = write_alert("push_cap_exceeded", {
             "p0_count": len(p0_rows), "cap": push_cap,
             "hint": "可能規則過鬆或水位回退/資料異常，停下檢查，未推 Slack",
+            "blocked_p0": blocked,  # 被擋的完整清單，供人工補救（水位已前進）
         })
         result.update(status="capped", alert=alert)
         # 水位仍前進（避免下輪重複爆量），但不推播
         commit_watermark(rows, state)
         append_runlog(state, fetched=len(rows), new=len(new_rows),
                       pushed=0, note=f"CAPPED p0={len(p0_rows)}>{push_cap}")
-        save_state(state, state_path)
-        return result
-
-    # 4. 時間封頂（軟檢查；硬 kill 靠 CI step timeout）
-    if time.time() - t0 > time_cap:
-        alert = write_alert("time_cap_exceeded",
-                            {"elapsed": round(time.time() - t0, 1), "cap": time_cap})
-        result.update(status="timeout", alert=alert)
-        append_runlog(state, fetched=len(rows), new=len(new_rows),
-                      pushed=0, note="TIMEOUT")
         save_state(state, state_path)
         return result
 
@@ -118,8 +117,8 @@ def main():
     res = run(args.weekly, args.state, dry_run=not args.push,
               push_cap=args.push_cap)
     print(json.dumps(res, ensure_ascii=False), file=sys.stderr)
-    # capped/timeout 用非零退出碼讓 CI 標紅（但不算 fetch 失敗）
-    if res["status"] in ("capped", "timeout"):
+    # capped 用非零退出碼讓 CI 標記降級（但不算 fetch 失敗）
+    if res["status"] == "capped":
         sys.exit(2)
 
 

--- a/scripts/watcher_diff.py
+++ b/scripts/watcher_diff.py
@@ -15,6 +15,7 @@ state schema:
   "runs": [ {ts, fetched, new, pushed, watermark} ... ]  # run-log（保留近 N 筆）
 }
 """
+import hashlib
 import json
 import os
 from datetime import datetime
@@ -24,10 +25,19 @@ RUNLOG_KEEP = 60  # 保留近 60 輪 run-log（每日跑 → 約 2 個月）
 
 
 def row_key(row: dict) -> str:
-    """sched 主鍵，對齊 merge.py PRIMARY_KEYS (unit_id, job_number, date)。"""
+    """sched 主鍵，對齊 merge.py PRIMARY_KEYS (unit_id, job_number, date)。
+
+    主鍵三欄若全空（"||"），多筆不同標案會被 find_new 的 seen_this_batch
+    去重成同一筆 → 漏報（issue #14 §4 0 漏報）。三欄全空時 fallback：
+    用 title + unit_name 的 hash 當 key，至少讓內容不同的列各自成 key。
+    """
     uid = row.get("unit_id") or row.get("agency_id") or ""
     job = row.get("job_number") or ""
     date = row.get("date") or ""
+    if not (uid or job or date):
+        seed = f"{row.get('title', '')}|{row.get('unit_name', '')}"
+        h = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:16]
+        return f"fallback|{h}"
     return f"{uid}|{job}|{date}"
 
 

--- a/scripts/watcher_diff.py
+++ b/scripts/watcher_diff.py
@@ -1,0 +1,95 @@
+"""watcher diff / 水位模組 — 找「上次 baseline 後新出現」的標案。
+
+設計（與 merge.py 解耦）：
+- merge.py 只負責去重合併進 master，不輸出 new rows（既有行為不動）。
+- 本模組獨立維護一份「已見過 key 水位」state（`data/watcher_state.json`），
+  每輪把 fetch 結果的 key 與水位比對，**水位裡沒有的 = 新出現**。
+- key 沿用 merge 主鍵 (unit_id, job_number, date)，去重邏輯一致。
+- 中止演練（brief §跑偏中止）＝把水位回退（刪掉部分 seen key），
+  下一輪會把大量舊案誤判為「新出現」→ 觸發成本封頂降級 alert。
+
+state schema:
+{
+  "seen_keys": ["unit_id|job_number|date", ...],   # 已推播過/已見過水位
+  "last_run": "2026-06-13T10:00:00",
+  "runs": [ {ts, fetched, new, pushed, watermark} ... ]  # run-log（保留近 N 筆）
+}
+"""
+import json
+import os
+from datetime import datetime
+
+STATE_PATH = "data/watcher_state.json"
+RUNLOG_KEEP = 60  # 保留近 60 輪 run-log（每日跑 → 約 2 個月）
+
+
+def row_key(row: dict) -> str:
+    """sched 主鍵，對齊 merge.py PRIMARY_KEYS (unit_id, job_number, date)。"""
+    uid = row.get("unit_id") or row.get("agency_id") or ""
+    job = row.get("job_number") or ""
+    date = row.get("date") or ""
+    return f"{uid}|{job}|{date}"
+
+
+def load_state(path: str = STATE_PATH) -> dict:
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            st = json.load(f)
+        st.setdefault("seen_keys", [])
+        st.setdefault("runs", [])
+        return st
+    return {"seen_keys": [], "last_run": None, "runs": []}
+
+
+def save_state(state: dict, path: str = STATE_PATH) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    # run-log 只保留近 N 筆
+    state["runs"] = state.get("runs", [])[-RUNLOG_KEEP:]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+
+
+def find_new(rows: list, state: dict) -> list:
+    """回傳水位裡沒見過的列（新出現）。不改 state（推播決策後才更新水位）。"""
+    seen = set(state.get("seen_keys", []))
+    new = []
+    seen_this_batch = set()
+    for r in rows:
+        k = row_key(r)
+        if k in seen or k in seen_this_batch:
+            continue
+        seen_this_batch.add(k)
+        new.append(r)
+    return new
+
+
+def commit_watermark(rows: list, state: dict) -> None:
+    """把本輪 fetch 的所有 key 併入水位（無論是否推播，見過就算）。"""
+    seen = set(state.get("seen_keys", []))
+    for r in rows:
+        seen.add(row_key(r))
+    state["seen_keys"] = sorted(seen)
+
+
+def rollback_watermark(state: dict, n: int) -> int:
+    """中止演練用：回退水位（刪掉 n 個 seen key）。回傳實際刪除數。
+
+    刪掉後，下一輪同一批舊案會被 find_new 當成新出現 → 大量 new → 觸發封頂。
+    """
+    keys = state.get("seen_keys", [])
+    n = min(n, len(keys))
+    state["seen_keys"] = keys[n:]  # 砍掉前 n 個
+    return n
+
+
+def append_runlog(state: dict, fetched: int, new: int, pushed: int,
+                  note: str = "") -> None:
+    state.setdefault("runs", []).append({
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "fetched": fetched,
+        "new": new,
+        "pushed": pushed,
+        "watermark": len(state.get("seen_keys", [])),
+        "note": note,
+    })
+    state["last_run"] = datetime.now().isoformat(timespec="seconds")

--- a/tests/test_drill_and_audit.py
+++ b/tests/test_drill_and_audit.py
@@ -1,0 +1,64 @@
+"""中止演練 + 0漏報對照 的回歸測試（brief §4 兩條 binary 驗收的可重複保證）。"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import drill_abort  # noqa: E402
+from audit_recall import audit  # noqa: E402
+
+
+def test_drill_abort_passes():
+    # 跑偏中止演練應回傳 0（封頂觸發、Slack 未被轟）
+    assert drill_abort.run_drill() == 0
+
+
+def _write_csv(path, rows):
+    cols = ["unit_id", "job_number", "date", "title", "unit_name", "type", "url"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for r in rows:
+            w.writerow({c: r.get(c, "") for c in cols})
+
+
+def test_audit_zero_miss_when_all_seen(tmp_path):
+    truth = tmp_path / "truth.csv"
+    statep = tmp_path / "s.json"
+    rows = [{"unit_id": f"U{i}", "job_number": f"J{i}", "date": "20260613",
+             "title": "圖書館資訊系統", "unit_name": "國立臺灣圖書館"} for i in range(3)]
+    _write_csv(truth, rows)
+    seen = [f"U{i}|J{i}|20260613" for i in range(3)]
+    statep.write_text(json.dumps({"seen_keys": seen}), encoding="utf-8")
+    missed, total = audit(str(truth), str(statep))
+    assert total == 3 and missed == []
+
+
+def test_audit_detects_miss(tmp_path):
+    truth = tmp_path / "truth.csv"
+    statep = tmp_path / "s.json"
+    rows = [{"unit_id": f"U{i}", "job_number": f"J{i}", "date": "20260613",
+             "title": "圖書館資訊系統", "unit_name": "國立臺灣圖書館"} for i in range(3)]
+    _write_csv(truth, rows)
+    # 只見過 2 筆 → 第 3 筆漏報
+    seen = ["U0|J0|20260613", "U1|J1|20260613"]
+    statep.write_text(json.dumps({"seen_keys": seen}), encoding="utf-8")
+    missed, total = audit(str(truth), str(statep))
+    assert total == 3 and len(missed) == 1 and missed[0]["unit_id"] == "U2"
+
+
+def test_audit_ignores_non_p0(tmp_path):
+    truth = tmp_path / "truth.csv"
+    statep = tmp_path / "s.json"
+    rows = [
+        {"unit_id": "U0", "job_number": "J0", "date": "20260613",
+         "title": "圖書館資訊系統", "unit_name": "國立臺灣圖書館"},
+        {"unit_id": "U1", "job_number": "J1", "date": "20260613",
+         "title": "辦公室清潔勞務", "unit_name": "某公司"},   # 非 P0
+    ]
+    _write_csv(truth, rows)
+    statep.write_text(json.dumps({"seen_keys": []}), encoding="utf-8")
+    missed, total = audit(str(truth), str(statep))
+    assert total == 1   # 只算 P0；清潔不計

--- a/tests/test_p0_rules.py
+++ b/tests/test_p0_rules.py
@@ -1,0 +1,89 @@
+"""P0 規則 unit test — 機關白名單 / 關鍵字 / 排除詞 各有案例（brief §4 驗收）。"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from p0_rules import hit_agency, hit_exclude, hit_keyword, is_p0  # noqa: E402
+
+
+# ---------- 機關白名單 ----------
+def test_agency_core_hit():
+    assert hit_agency("國立臺灣圖書館")
+    assert hit_agency("臺北市立圖書館")        # 「圖書館」子字串
+    assert hit_agency("內政部移民署")
+    assert hit_agency("數位發展部")
+
+
+def test_agency_strategic_hit():
+    assert hit_agency("行政院公共工程委員會")
+    assert hit_agency("法務部廉政署")
+    assert hit_agency("某部會政風室")
+
+
+def test_agency_miss():
+    assert not hit_agency("國防部")            # 不在白名單
+    assert not hit_agency("某私人公司")
+    assert not hit_agency("")
+
+
+# ---------- 關鍵字 ----------
+def test_keyword_existing_dict_reused():
+    # 複用既有 KEYWORDS（不另立平行字典）
+    assert hit_keyword("某機關資訊系統建置案")
+    assert hit_keyword("官方網站改版")
+    assert hit_keyword("AI 應用程式開發")
+
+
+def test_keyword_p0_extra():
+    # P0 加強層補的詞
+    assert hit_keyword("圖書館借閱系統")        # 借閱（既有也有系統，但測 P0 詞獨立可命中）
+    assert hit_keyword("無障礙網頁 WCAG 改善")
+    assert hit_keyword("政府開放資料平台委外維護")
+
+
+def test_keyword_miss():
+    assert not hit_keyword("辦公室清潔勞務")
+    assert not hit_keyword("")
+
+
+# ---------- 排除詞 ----------
+def test_exclude_existing_blacklist():
+    assert hit_exclude("道路橋樑工程")          # 既有 BLACKLIST「工程」「橋樑」
+    assert hit_exclude("空調機電維護")
+
+
+def test_exclude_p0_extra():
+    assert hit_exclude("校園監視系統建置")      # P0 排除補充
+    assert hit_exclude("門禁系統")
+    assert hit_exclude("文件翻譯服務")
+
+
+def test_exclude_miss():
+    assert not hit_exclude("資訊系統開發")
+    assert not hit_exclude("")
+
+
+# ---------- is_p0 整合 ----------
+def test_is_p0_agency_path():
+    # 機關命中 → P0（即使 title 關鍵字弱）
+    assert is_p0({"unit_name": "國立臺灣圖書館", "title": "圖書借閱服務系統"})
+
+
+def test_is_p0_keyword_path():
+    # 機關不在白名單但關鍵字強 → P0
+    assert is_p0({"unit_name": "某市政府", "title": "市民服務 App 開發建置"})
+
+
+def test_is_p0_exclude_overrides():
+    # 排除詞優先級最高：即使機關命中也否決
+    assert not is_p0({"unit_name": "國立臺灣圖書館", "title": "圖書館門禁監視系統工程"})
+
+
+def test_is_p0_neither():
+    assert not is_p0({"unit_name": "某私人公司", "title": "辦公室清潔勞務採購"})
+
+
+def test_is_p0_handles_agency_key_alias():
+    # 餵原始 pcc row（agency 欄）也能判
+    assert is_p0({"agency": "數位發展部", "title": "資料治理平台"})

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,100 @@
+"""watcher 主流程 + Slack 推播 + 成本封頂 unit test。"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import watcher  # noqa: E402
+from slack_notify import build_payload, notify  # noqa: E402
+
+
+def _write_csv(path, rows):
+    cols = ["unit_id", "job_number", "date", "title", "unit_name", "type", "url"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for r in rows:
+            w.writerow({c: r.get(c, "") for c in cols})
+
+
+def _p0_row(i, agency="國立臺灣圖書館", title="圖書館資訊系統建置"):
+    return {"unit_id": f"U{i}", "job_number": f"J{i}", "date": "20260613",
+            "title": title, "unit_name": agency, "type": "公開招標", "url": "http://x"}
+
+
+# ---------- Slack ----------
+def test_build_payload_structure():
+    p = build_payload([_p0_row(1)])
+    assert "blocks" in p and p["blocks"][0]["type"] == "header"
+    assert "1 則" in p["blocks"][0]["text"]["text"]
+
+
+def test_notify_dry_run_does_not_send():
+    res = notify([_p0_row(1)], dry_run=True)
+    assert res["sent"] is False and res["reason"] == "dry_run"
+
+
+def test_notify_no_webhook_safe_degrade():
+    # dry_run=False 但無 webhook → 不報錯、安全降級
+    res = notify([_p0_row(1)], dry_run=False, webhook="")
+    assert res["sent"] is False and res["reason"] == "no_webhook"
+
+
+# ---------- watcher 主流程 ----------
+def test_run_first_pass_all_new_p0(tmp_path):
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    _write_csv(csvp, [_p0_row(i) for i in range(3)])
+    res = watcher.run(str(csvp), str(statep), dry_run=True)
+    assert res["fetched"] == 3 and res["new"] == 3
+    assert res["p0"] == 3 and res["pushed"] == 3 and res["status"] == "ok"
+
+
+def test_run_filters_non_p0(tmp_path):
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    rows = [_p0_row(1)] + [
+        {"unit_id": "X", "job_number": "JX", "date": "20260613",
+         "title": "辦公室清潔勞務", "unit_name": "某公司", "type": "公開招標", "url": ""}
+    ]
+    _write_csv(csvp, rows)
+    res = watcher.run(str(csvp), str(statep), dry_run=True)
+    assert res["new"] == 2 and res["p0"] == 1   # 清潔被排除
+
+
+def test_run_second_pass_no_new(tmp_path):
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    _write_csv(csvp, [_p0_row(i) for i in range(3)])
+    watcher.run(str(csvp), str(statep), dry_run=True)   # 第一輪
+    res = watcher.run(str(csvp), str(statep), dry_run=True)  # 第二輪同檔
+    assert res["new"] == 0 and res["pushed"] == 0
+
+
+def test_cost_cap_triggers_alert_no_push(tmp_path, monkeypatch):
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    _write_csv(csvp, [_p0_row(i) for i in range(25)])  # 25 > cap 20
+    res = watcher.run(str(csvp), str(statep), dry_run=True, push_cap=20)
+    assert res["status"] == "capped"
+    assert res["pushed"] == 0
+    assert res["alert"] is not None
+    # alert 檔有寫
+    assert Path(res["alert"]).exists()
+    payload = json.loads(Path(res["alert"]).read_text(encoding="utf-8"))
+    assert payload["kind"] == "push_cap_exceeded" and payload["p0_count"] == 25
+
+
+def test_runlog_written(tmp_path):
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    _write_csv(csvp, [_p0_row(i) for i in range(2)])
+    watcher.run(str(csvp), str(statep), dry_run=True)
+    st = json.loads(statep.read_text(encoding="utf-8"))
+    assert len(st["runs"]) == 1
+    run = st["runs"][0]
+    assert run["fetched"] == 2 and run["new"] == 2 and run["pushed"] == 2
+    assert "watermark" in run

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import watcher  # noqa: E402
+import watcher_diff  # noqa: E402
 from slack_notify import build_payload, notify  # noqa: E402
 
 
@@ -86,6 +87,51 @@ def test_cost_cap_triggers_alert_no_push(tmp_path, monkeypatch):
     assert Path(res["alert"]).exists()
     payload = json.loads(Path(res["alert"]).read_text(encoding="utf-8"))
     assert payload["kind"] == "push_cap_exceeded" and payload["p0_count"] == 25
+
+
+def test_cost_cap_alert_includes_blocked_list(tmp_path, monkeypatch):
+    """0 漏報鐵則：capped 時水位前進，alert 必須含被擋 P0 完整清單供人工補救。"""
+    csvp = tmp_path / "w.csv"
+    statep = tmp_path / "s.json"
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    rows = [_p0_row(i, title=f"圖書館資訊系統建置-{i}") for i in range(25)]
+    _write_csv(csvp, rows)
+    res = watcher.run(str(csvp), str(statep), dry_run=True, push_cap=20)
+    payload = json.loads(Path(res["alert"]).read_text(encoding="utf-8"))
+    blocked = payload["blocked_p0"]
+    # 全部 25 筆被擋的 P0 都要在清單裡，且帶可辨識欄位
+    assert len(blocked) == 25
+    sample = blocked[0]
+    assert {"title", "unit_name", "job_number"} <= set(sample)
+    # 內容不是空殼：title/job_number 對得回原始列
+    titles = {b["title"] for b in blocked}
+    assert titles == {f"圖書館資訊系統建置-{i}" for i in range(25)}
+    jobs = {b["job_number"] for b in blocked}
+    assert jobs == {f"J{i}" for i in range(25)}
+
+
+# ---------- watcher_diff 空 key 去重 ----------
+def test_empty_key_rows_not_deduped(tmp_path):
+    """三主鍵全空的不同標案不可被去重成一筆（否則漏報；issue #14 §4）。"""
+    rows = [
+        {"unit_id": "", "agency_id": "", "job_number": "", "date": "",
+         "title": "甲案：系統建置", "unit_name": "A 機關"},
+        {"unit_id": "", "agency_id": "", "job_number": "", "date": "",
+         "title": "乙案：系統建置", "unit_name": "B 機關"},
+    ]
+    # 兩筆內容不同 → key 必須不同
+    assert watcher_diff.row_key(rows[0]) != watcher_diff.row_key(rows[1])
+    # find_new 不去重，兩筆都算新出現
+    new = watcher_diff.find_new(rows, {"seen_keys": []})
+    assert len(new) == 2
+
+
+def test_empty_key_same_content_still_deduped(tmp_path):
+    """主鍵全空但內容完全相同 → 仍視為同一筆去重（fallback 用 title+unit_name）。"""
+    r = {"unit_id": "", "job_number": "", "date": "",
+         "title": "同案", "unit_name": "同機關"}
+    new = watcher_diff.find_new([dict(r), dict(r)], {"seen_keys": []})
+    assert len(new) == 1
 
 
 def test_runlog_written(tmp_path):

--- a/tests/test_watcher_diff.py
+++ b/tests/test_watcher_diff.py
@@ -1,0 +1,88 @@
+"""watcher diff / 水位 unit test。"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from watcher_diff import (  # noqa: E402
+    append_runlog,
+    commit_watermark,
+    find_new,
+    load_state,
+    rollback_watermark,
+    row_key,
+    save_state,
+)
+
+
+def _row(uid, job, date, title="案", agency="機關"):
+    return {"unit_id": uid, "job_number": job, "date": date,
+            "title": title, "unit_name": agency}
+
+
+def test_row_key_matches_merge_primary():
+    assert row_key(_row("A", "J1", "20260613")) == "A|J1|20260613"
+
+
+def test_row_key_falls_back_to_agency_id():
+    assert row_key({"agency_id": "X", "job_number": "J", "date": "20260613"}) == "X|J|20260613"
+
+
+def test_find_new_all_new_on_empty_state():
+    st = {"seen_keys": []}
+    rows = [_row("A", "J1", "20260613"), _row("B", "J2", "20260613")]
+    assert len(find_new(rows, st)) == 2
+
+
+def test_find_new_filters_seen():
+    st = {"seen_keys": ["A|J1|20260613"]}
+    rows = [_row("A", "J1", "20260613"), _row("B", "J2", "20260613")]
+    new = find_new(rows, st)
+    assert len(new) == 1
+    assert new[0]["unit_id"] == "B"
+
+
+def test_find_new_dedups_within_batch():
+    st = {"seen_keys": []}
+    rows = [_row("A", "J1", "20260613"), _row("A", "J1", "20260613")]
+    assert len(find_new(rows, st)) == 1
+
+
+def test_commit_watermark_grows_seen():
+    st = {"seen_keys": []}
+    commit_watermark([_row("A", "J1", "20260613"), _row("B", "J2", "20260613")], st)
+    assert set(st["seen_keys"]) == {"A|J1|20260613", "B|J2|20260613"}
+
+
+def test_rollback_makes_old_rows_new_again():
+    # 中止演練核心：回退水位 → 舊案重新被當新出現
+    st = {"seen_keys": []}
+    rows = [_row(str(i), "J", "20260613") for i in range(10)]
+    commit_watermark(rows, st)
+    assert len(find_new(rows, st)) == 0          # 都見過
+    removed = rollback_watermark(st, 8)
+    assert removed == 8
+    assert len(find_new(rows, st)) == 8          # 8 個又變新出現
+
+
+def test_rollback_caps_at_available():
+    st = {"seen_keys": ["A|J|D"]}
+    assert rollback_watermark(st, 99) == 1
+    assert st["seen_keys"] == []
+
+
+def test_runlog_append_and_trim(tmp_path):
+    st = {"seen_keys": [], "runs": []}
+    for i in range(70):
+        append_runlog(st, fetched=i, new=0, pushed=0)
+    p = tmp_path / "state.json"
+    save_state(st, str(p))
+    reloaded = load_state(str(p))
+    assert len(reloaded["runs"]) == 60          # RUNLOG_KEEP
+
+
+def test_save_load_roundtrip(tmp_path):
+    p = tmp_path / "s.json"
+    st = {"seen_keys": ["A|J|D"], "last_run": None, "runs": []}
+    save_state(st, str(p))
+    assert load_state(str(p))["seen_keys"] == ["A|J|D"]


### PR DESCRIPTION
closes #14（部分 — Slack 停在 dry-run，待 Jay 設 secret 接真頻道；勿直接 close）

## 做了什麼

在既有 fetch→merge 管線末端加「P0 標案 watcher → Slack 推播」，做成可觀測、有成本封頂的常駐 loop pilot。**真交付物＝observability + 成本封頂**，標案推播是載體。

走 4 道閘：spec 先行（issue #14）→ 小步 commit（5 邏輯單元）→ 綠燈測試（63 passed, 5 xfailed）→ ADR（`docs/adr/0001`）。evaluator 全程**零 LLM**（diff 字串 key + P0 布林規則）。

## 新增檔

| 檔 | 作用 |
|---|---|
| `scripts/p0_rules.py` | P0 純布林判定（機關白名單 OR 關鍵字 AND NOT 排除詞），複用既有 KEYWORDS/BLACKLIST 單一事實源 |
| `scripts/watcher_diff.py` | 水位 state（`data/watcher_state.json`）找新出現標案；key 對齊 merge 主鍵；rollback 供演練 |
| `scripts/slack_notify.py` | Slack Block Kit payload，讀 env `SLACK_WEBHOOK_URL`，預設 dry-run |
| `scripts/watcher.py` | 主流程：diff→P0→成本封頂→Slack→run-log |
| `scripts/drill_abort.py` | 跑偏中止演練（可重複，回 0=PASSED） |
| `scripts/audit_recall.py` | 0 漏報對照腳本 |
| `.github/workflows/daily-watcher.yml` | 每日 workflow，cron 停用、timeout 10min |
| `docs/adr/0001-*.md` | 6 個架構決策 |
| `tests/test_p0_rules.py` `test_watcher_diff.py` `test_watcher.py` `test_drill_and_audit.py` | 36 新測試 |

## brief §4 驗收對照

| 驗收項 | 狀態 | 證據 |
|---|---|---|
| 成本封頂可驗（>20→降級 alert 不推，單元測試） | ✅ | `test_watcher.py::test_cost_cap_triggers_alert_no_push` |
| 跑偏中止演練 1 次成功（可重複） | ✅ | `scripts/drill_abort.py` 回 0；`test_drill_and_audit.py::test_drill_abort_passes` |
| 每輪寫 run-log（時間/查幾筆/新增/推幾則/水位）可查 | ✅ | `watcher_state.json.runs`；`test_runlog_written` |
| P0 規則有 unit test（白名單/關鍵字/排除詞各案例） | ✅ | `test_p0_rules.py` 14 測試 |
| 既有 tests 全綠 + 新增綠 | ✅ | 63 passed, 5 xfailed |
| 0 漏報對照腳本 | ✅ | `scripts/audit_recall.py` + 4 回歸測試 |
| 連續 7 天 0 漏報 | ⏳ 待運行 | workflow + audit 腳本已就緒，需啟用後跑 7 天 |
| 誤報不設硬上限但 run-log 可算誤報 | ✅ | run-log 記 pushed/new，可事後標註 |

## ⚠️ Checkpoint 狀態（issue #14 §7）：停在 Slack webhook 整合點

- **已完成**：推播函數讀 env `SLACK_WEBHOOK_URL` + dry-run 印 payload（`build_payload`/`notify`）。
- **停點（需 Jay 做）**：
  1. repo Settings → Secrets 設 `TWINKLE_API_KEY`、`SLACK_WEBHOOK_URL`（Slack webhook **不由 agent 建**）。
  2. 確認 `build_payload` 的 Slack 訊息格式 OK（Block Kit header + section）。
  3. 確認後 workflow_dispatch 帶 `push=true` 驗一次真推；OK 再取消 cron 註解啟用每日排程。
- **未做（守邊界）**：不 merge、不 push main、不啟用正式 schedule、不建 webhook、不推真頻道。

## reviewer 重點

- ADR D3：為何 diff 另開模組不改 merge.py（職責分離 vs 雙水位 drift 取捨）
- ADR D4：成本封頂閾值 20 是 pilot 拍板值，可調 `--push-cap`
- P0 字典分層（D2）：`p0_rules.py` 只補既有沒有的詞，reviewer 看 docstring 確認無平行字典

🤖 Generated with [Claude Code](https://claude.com/claude-code)
