### PR TITLE
fix: watcher 修間歇 401 + 加失敗告警（消滅靜默失敗）#17

### DIFF
--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -73,11 +73,26 @@ jobs:
             exit "$ec"
           fi
 
+      # 任一前置 step 失敗 → 寫失敗告警 alert（消滅靜默失敗）。
+      # 退出碼 0 不再連鎖失敗；alert markdown 隨下方 commit step 進 repo（留痕）。
+      # 心跳：notify_failure 讀 watcher_state.last_run，連續 ≥3 天無成功 → 升級 high。
+      - name: 失敗告警（寫 alert）
+        if: failure()
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          python scripts/notify_failure.py \
+            --reason "daily watcher run 失敗（fetch/merge/watcher 任一 step）" \
+            --run-url "$RUN_URL" \
+            --state data/watcher_state.json \
+            --out-dir data/alerts
+
+      # always()：即便前面失敗也要把 state / alert 提交留痕（含失敗告警 md）。
       - name: Commit state + master + alerts
+        if: always()
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/bids.csv data/watcher_state.json data/alerts 2>/dev/null || true
           git diff --cached --quiet || \
-            git commit -m "watcher: daily run $(date -u +%Y-%m-%dT%H:%M) (state+runlog)"
-          git push
+            git commit -m "watcher: daily run $(date -u +%Y-%m-%dT%H:%M) (state/runlog/alert)"
+          git push || true

--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -87,12 +87,30 @@ jobs:
             --out-dir data/alerts
 
       # always()：即便前面失敗也要把 state / alert 提交留痕（含失敗告警 md）。
+      # ⚠️ push 失敗「不可隱形」（codex high）：若有東西 commit 了卻 push 不上去，
+      # 告警/state watermark 沒進 repo → 下輪拿舊 state 重算、失敗證據遺失。
+      # 故 push 失敗時讓本 job 紅燈，不再 `|| true` 吞掉。
+      # 容錯：先 rebase 重試（吸收併發 non-fast-forward），仍失敗才 fail。
       - name: Commit state + master + alerts
         if: always()
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/bids.csv data/watcher_state.json data/alerts 2>/dev/null || true
-          git diff --cached --quiet || \
-            git commit -m "watcher: daily run $(date -u +%Y-%m-%dT%H:%M) (state/runlog/alert)"
-          git push || true
+          if git diff --cached --quiet; then
+            echo "沒有需要提交的變更，略過 push。"
+            exit 0
+          fi
+          git commit -m "watcher: daily run $(date -u +%Y-%m-%dT%H:%M) (state/runlog/alert)"
+          # push 重試：non-fast-forward 時 rebase 後再推，最多 3 次；全失敗 → 紅燈喊人。
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "push 成功（第 $attempt 次嘗試）。"
+              exit 0
+            fi
+            echo "::warning::push 第 $attempt 次失敗，rebase 後重試…"
+            git pull --rebase --autostash origin "${GITHUB_REF_NAME}" || true
+          done
+          echo "::error::state/alert push 連續 3 次失敗——告警與 watcher_state 未進 repo，本 job 判定失敗（不靜默）。"
+          exit 1

--- a/data/alerts/2026-06-23-gov-bid-watch-watcher-fail.md
+++ b/data/alerts/2026-06-23-gov-bid-watch-watcher-fail.md
@@ -1,0 +1,11 @@
+# gov-bid-watch watcher 失敗 | 2026-06-23
+
+- 嚴重度：中（單日失敗，可能間歇）
+- 失敗原因：daily watcher run 失敗（fetch/merge/watcher 任一 step）
+- 失敗 run：https://github.com/Hyweb-JayKao/gov-bid-watch/actions/runs/28005843554
+- 上次成功：2026-06-22T05:06:27（距今 1 天）
+
+## 怎麼處理
+- 單日失敗。fetch 已內建 retry（401/5xx/timeout 指數 backoff 5 次），
+  仍失敗代表閘道持續抖動或 retry 用盡 → 觀察隔日是否自動恢復。
+- 若連續 ≥ 3 天無成功，本告警會自動升級為 high。

--- a/docs/adr/0002-watcher-retry-and-failure-alert.md
+++ b/docs/adr/0002-watcher-retry-and-failure-alert.md
@@ -1,0 +1,51 @@
+# ADR 0002 — watcher 間歇 401 retry + 失敗告警
+
+- 狀態：Proposed（待 Jay/RD review，issue #17）
+- 日期：2026-06-23
+- 脈絡：issue #17（watcher ~50% 間歇失敗且靜默無人知）
+
+## 背景
+
+`daily-watcher.yml` 每日跑，6/16 起呈 ✅❌✅❌ 約 50% 間歇失敗，且 workflow 無任何告警 → 靜默。
+6/23 失敗根因：`fetch_pcc.py` 對 TwinkleAI 的請求收到 401 直接 raise、無 retry。
+
+## 決策
+
+### D1. 401 判讀為「閘道間歇抖動」，retry 是對症解（非 key 問題）
+
+失敗 run 的 401 回的是**裸 nginx HTML 401 頁**，不是 MCP app 層的 JSON-RPC 認證 error。
+
+- 判讀：key 失效會回 JSON-RPC error（帶 code/message）；裸 nginx 401＝請求沒到達 app，被閘道層擋（rate-limit / upstream 抖動）。run 歷史間歇成功也證明 key 有效。
+- 為何重要：若是 key 死掉，retry 無用、該停下喊人；既然是閘道抖動，retry + backoff 正中要害。
+- 反方：萬一哪天真是配額耗盡，retry 會多燒幾次配額。取捨：retry 設 5 次上限 + 指數 backoff 封頂，最壞多打 4 次；且配額耗盡會走「連續無成功」心跳升級成 high 喊人。
+
+### D2. retry 用 tenacity 包在 `MCP._post`，區分暫時/永久錯
+
+- 包 `_post`（HTTP 邊界）而非更上層：所有對 TwinkleAI 的請求（initialize / query_rows）都過 `_post`，一處收斂。
+- **暫時性**（401/429/5xx/timeout/connection）→ raise `TransientHTTPError` → 觸發 retry；**永久性**（400 session 錯、403 永久拒、app 層 JSON-RPC error）→ raise 一般 `RuntimeError`，不重試、立即失敗喊人。避免對邏輯錯誤盲目重試。
+- backoff：`wait_exponential(1, max=10)` = 1→2→4→8s，`stop_after_attempt(5)`。最壞累計 sleep ~15s，遠在 job 10 分鐘 timeout 內。
+- tenacity 顯式加進 requirements.txt（原本只透過 streamlit 傳遞性帶入，不該依賴傳遞依賴）。
+
+### D3. 失敗告警寫 markdown alert，CI 落 repo、本機落 FLUX Inbox
+
+GitHub Actions runner 寫不到 Jay 本機 `~/Documents/FLUX/`，故告警 script `notify_failure.py` 用 `--out-dir` 參數化落點。
+
+- CI：`if: failure()` step 呼叫 → 寫進 repo `data/alerts/`，隨 commit step（改 `if: always()`）留痕；Jay 從 repo / commit 看得到。本機跑預設寫 FLUX Inbox `agent-alert/`，沿用既有 agent-alert markdown 格式。
+- 為何 markdown 不 JSON：告警給人讀，沿用 FLUX agent-alert 慣例（H1 + 條列脈絡）。既有 `data/alerts/` 的 push_cap JSON 是機器留痕用途，兩者不同目的、不混。
+- 反方：alert 落 repo 需 commit step `always()`，失敗時也跑 commit/push。取捨：`git push || true` 不讓告警提交再次連鎖失敗。
+
+### D4. 心跳升級：連續 ≥3 天無成功 → high
+
+`notify_failure.py` 讀 `watcher_state.json` 的 `last_run`（只在成功跑完才更新 → 代表最後一次成功），算距今天數。
+
+- < 3 天：中度（可能間歇，retry 已擋一層，觀察隔日自動恢復）。
+- ≥ 3 天：升級 high，文案提示人工介入（查 key / 配額 / 對外聯絡 / 換源）。
+- 為何 3：間歇抖動最多連兩天巧合，連 3 天無成功＝系統性問題非運氣，該喊人。閾值 `--stale-days` 可調。
+- state 讀不到（缺失/損壞）→ 保守不升級 high（避免誤判），但仍寫告警標明「無法判讀 state」。
+
+## 驗收對應
+
+- ① retry 對 401/5xx/timeout 生效 + 測試 → D1/D2 + `test_fetch_pcc_retry.py`
+- ② pytest 全綠 → 86 passed
+- ③ 任一日失敗 → 寫 Inbox alert → D3 + workflow `if: failure()` step + `test_notify_failure.py`
+- ④ dispatch 驗證 → 見 issue #17 comment（手動 dispatch 結果）

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.31
+tenacity>=8.2
 pandas>=2.2
 streamlit>=1.32
 streamlit-option-menu>=0.3.6

--- a/scripts/fetch_pcc.py
+++ b/scripts/fetch_pcc.py
@@ -26,9 +26,40 @@ import time
 from datetime import datetime, timedelta
 
 import requests
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 # 軟體開發類過濾規則沿用 g0v fetcher（單一事實源，不重複維護）
 from fetch_bids import BLACKLIST, KEYWORDS, pre_filter  # noqa: E402
+
+
+# ---------- 暫時性錯誤 → 觸發 retry（永久性錯誤不重試，免燒配額）----------
+class TransientHTTPError(RuntimeError):
+    """閘道層間歇錯誤（裸 nginx 401 / 5xx / timeout）→ 值得 retry。
+
+    與 app 層 JSON-RPC error 區分：後者是邏輯錯（工具名/SQL/配額耗盡），
+    retry 無用，由 query_rows 另行 raise RuntimeError 不進這條。
+    """
+
+
+# 401 = TwinkleAI 閘道間歇抖動（回裸 nginx 頁、非 JSON-RPC 認證錯，run 歷史呈
+#       ✅❌✅❌ 間歇 → 非 key 死掉）；5xx = 上游暫時不可用；皆暫時性值得 retry。
+RETRY_STATUS = frozenset({401, 429, 500, 502, 503, 504})
+
+# retry 上限 5 次嘗試（首發 + 4 retry），指數 backoff 1→2→4→8s（封頂 10s），
+# 設上限避免閘道持續 401 時無限重試燒配額/CI 時間（job timeout 10 分鐘內收斂）。
+_RETRY_KW = dict(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(
+        (TransientHTTPError, requests.Timeout, requests.ConnectionError)
+    ),
+    reraise=True,
+)
 
 ENDPOINT = "https://api.twinkleai.tw/mcp/"
 DATASET = "pcc-tender"
@@ -78,8 +109,15 @@ class MCP:
         self._id += 1
         return self._id
 
+    @retry(**_RETRY_KW)
     def _post(self, payload):
-        r = self.s.post(ENDPOINT, headers=self.h, json=payload, timeout=120)
+        # @retry：閘道層間歇 401/5xx/timeout 自動指數 backoff 重試（見 _RETRY_KW）。
+        # 每次重試重新發 POST，session header（含 Mcp-Session-Id）沿用。
+        try:
+            r = self.s.post(ENDPOINT, headers=self.h, json=payload, timeout=120)
+        except (requests.Timeout, requests.ConnectionError):
+            # 連線層暫時性失敗 → 原樣往上拋，由 @retry 攔截重試
+            raise
         r.encoding = "utf-8"
         # MCP streamable HTTP（2025 transport）：initialize 的 response header 帶
         # Mcp-Session-Id，後續所有請求必須回帶，否則 server 回 400 Missing session ID。
@@ -91,7 +129,12 @@ class MCP:
         # "no valid response" 而盲猜根因——2026-06-13 token/工具名 debug 教訓）
         # 200 = 有 body 的回應；202 = notification 被接受（無 body，正常）
         if r.status_code not in (200, 202):
-            raise RuntimeError(f"HTTP {r.status_code} from {ENDPOINT}: {r.text[:300]}")
+            msg = f"HTTP {r.status_code} from {ENDPOINT}: {r.text[:300]}"
+            # 暫時性狀態（裸 nginx 401 閘道抖動 / 5xx / 429）→ 觸發 retry；
+            # 其餘（如 400 session 錯、403 永久拒）→ 永久性錯，不重試直接 raise。
+            if r.status_code in RETRY_STATUS:
+                raise TransientHTTPError(msg)
+            raise RuntimeError(msg)
         out = []
         for line in r.text.splitlines():
             if line.startswith("data:"):

--- a/scripts/notify_failure.py
+++ b/scripts/notify_failure.py
@@ -27,50 +27,110 @@ DEFAULT_FLUX_INBOX = os.path.expanduser("~/Documents/FLUX/Inbox/agent-alert")
 
 
 def days_since_last_success(state_path: str):
-    """回 (last_run_iso, days_int) ；讀不到 state 回 (None, None)。
+    """回 (last_run_iso, days_int, state_error)。
 
     watcher_state.json 的 last_run 只在 watcher 成功跑完才更新，
     故它代表「最後一次成功」。距今天數 = 連續無成功天數的下界。
+
+    state_error 區分「為什麼算不出天數」：
+    - None：正常讀到 last_run，回 (last, days, None)。
+    - "missing"：state 檔不存在 / 讀不到（OSError）。
+    - "corrupt"：state 檔在但 JSON 壞、結構錯（json/KeyError/型別錯）。
+    - "unparseable"：有 last_run 但時間格式無法解析（ValueError）。
+    - "no_last_run"：state 可讀但根本沒 last_run 欄位（從沒成功過 / 被清空）。
+
+    ⚠️ 任何「算不出上次成功時間」（state_error 非 None）都不能保守降級——
+    無法證明上次成功＝可能已壞很久，必須由 build_alert 升級為 high/critical。
     """
+    import json
     try:
-        import json
         with open(state_path, encoding="utf-8") as f:
-            d = json.load(f)
-        last = d.get("last_run")
-        if not last:
-            return None, None
+            raw = f.read()
+    except OSError:
+        return None, None, "missing"
+    try:
+        d = json.loads(raw)
+    except ValueError:
+        return None, None, "corrupt"
+    if not isinstance(d, dict):
+        return None, None, "corrupt"
+    last = d.get("last_run")
+    if not last:
+        return None, None, "no_last_run"
+    try:
         delta = datetime.now() - datetime.fromisoformat(last)
-        return last, delta.days
-    except (OSError, ValueError, KeyError):
-        return None, None
+    except (ValueError, TypeError):
+        return None, None, "unparseable"
+    return last, delta.days, None
+
+
+_STATE_ERROR_LABEL = {
+    "missing": "watcher_state 檔缺失（讀不到）",
+    "corrupt": "watcher_state JSON 損壞 / 結構錯誤",
+    "unparseable": "watcher_state.last_run 時間格式無法解析",
+    "no_last_run": "watcher_state 可讀但無 last_run（從未成功 / 被清空）",
+}
 
 
 def build_alert(reason: str, run_url: str, last_run, stale_days_actual,
-                stale_threshold: int):
-    """組 agent-alert markdown 字串。回 (filename, content, is_high)。"""
+                stale_threshold: int, state_error=None):
+    """組 agent-alert markdown 字串。回 (filename, content, severity)。
+
+    severity ∈ {"mid", "high", "critical"}：
+    - "critical"：state 本身不可讀（missing/corrupt/unparseable）→ 連「上次何時成功」
+      都無從得知，盲區，最高優先（unknown_last_success）。
+    - "high"：能讀到天數且 ≥ 閾值（確知連續多日無成功），或 no_last_run（確知從沒成功）。
+    - "mid"：能讀到天數且 < 閾值（單日失敗，可能間歇）。
+
+    ⚠️ 不可讀 state 永不可降級成 mid——無法證明上次成功＝不能假設它最近成功過。
+    """
     today = datetime.now().strftime("%Y-%m-%d")
-    is_high = stale_days_actual is not None and stale_days_actual >= stale_threshold
-    sev = "high（連續多日無成功）" if is_high else "中（單日失敗，可能間歇）"
+
+    if state_error in ("missing", "corrupt", "unparseable"):
+        severity = "critical"
+    elif state_error == "no_last_run":
+        severity = "high"
+    elif stale_days_actual is not None and stale_days_actual >= stale_threshold:
+        severity = "high"
+    else:
+        severity = "mid"
+
+    sev_label = {
+        "critical": "critical（state 不可讀，上次成功未知 unknown_last_success）",
+        "high": "high（連續多日無成功 / 從未成功）",
+        "mid": "中（單日失敗，可能間歇）",
+    }[severity]
 
     lines = [
         f"# gov-bid-watch watcher 失敗 | {today}",
         "",
-        f"- 嚴重度：{sev}",
+        f"- 嚴重度：{sev_label}",
         f"- 失敗原因：{reason}",
     ]
     if run_url:
         lines.append(f"- 失敗 run：{run_url}")
     if last_run:
         lines.append(f"- 上次成功：{last_run}（距今 {stale_days_actual} 天）")
+    elif state_error:
+        lines.append(
+            f"- 上次成功：**無法判讀**——{_STATE_ERROR_LABEL[state_error]}")
     else:
         lines.append("- 上次成功：無法判讀 watcher_state（state 缺失或損壞）")
     lines += [
         "",
         "## 怎麼處理",
     ]
-    if is_high:
+    if severity == "critical":
         lines += [
-            f"- ⚠️ 已連續 ≥ {stale_threshold} 天無成功 run，**非間歇抖動**，需人工介入：",
+            f"- ⚠️ **{_STATE_ERROR_LABEL.get(state_error, 'state 不可讀')}**——"
+            "連上次成功時間都讀不到，無法判斷壞了多久，視為最高優先：",
+            "  - 檢查 repo `data/watcher_state.json` 是否遺失 / 被覆寫 / 內容毀損；必要時從歷史 commit 還原。",
+            "  - 同時查 TwinkleAI key/配額（裸 401 通常是閘道，JSON-RPC error 才是 key）。",
+            "  - state 修復前，後續每次失敗都會維持 critical 不會自動降級。",
+        ]
+    elif severity == "high":
+        lines += [
+            f"- ⚠️ 已連續 ≥ {stale_threshold} 天無成功 run（或從未成功），**非間歇抖動**，需人工介入：",
             "  - 查 TwinkleAI key 是否仍有效 / 配額是否耗盡（裸 401 通常是閘道，JSON-RPC error 才是 key）。",
             "  - 必要時對外聯絡 TwinkleAI 或更換資料源。",
         ]
@@ -82,7 +142,7 @@ def build_alert(reason: str, run_url: str, last_run, stale_days_actual,
         ]
     content = "\n".join(lines) + "\n"
     fname = f"{today}-gov-bid-watch-watcher-fail.md"
-    return fname, content, is_high
+    return fname, content, severity
 
 
 def main():
@@ -96,16 +156,17 @@ def main():
                     help="距上次成功 ≥ N 天 → 升級 high")
     args = ap.parse_args()
 
-    last_run, stale = days_since_last_success(args.state)
-    fname, content, is_high = build_alert(
-        args.reason, args.run_url, last_run, stale, args.stale_days)
+    last_run, stale, state_error = days_since_last_success(args.state)
+    fname, content, severity = build_alert(
+        args.reason, args.run_url, last_run, stale, args.stale_days,
+        state_error=state_error)
 
     os.makedirs(args.out_dir, exist_ok=True)
     path = os.path.join(args.out_dir, fname)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
 
-    sev = "HIGH" if is_high else "MID"
+    sev = severity.upper()
     print(f"[notify_failure:{sev}] -> {path}", file=sys.stderr)
     print(f"::warning::watcher 失敗告警已寫入 {path}（{sev}）", file=sys.stderr)
     return 0

--- a/scripts/notify_failure.py
+++ b/scripts/notify_failure.py
@@ -1,0 +1,115 @@
+"""watcher 失敗告警：寫一張 markdown alert，消滅「靜默失敗」。
+
+兩件事：
+1. **當日失敗告警**：watcher 任一日跑失敗 → 寫一張 agent-alert markdown，
+   讓 Jay 在 FLUX Inbox（本機）或 repo data/alerts/（CI）一眼看到。
+2. **心跳升級**：讀 watcher_state.json 的 last_run，算「距上次成功幾天」；
+   超過 --stale-days（預設 3）→ 告警升級為「連續多日無成功」，標 severity=high。
+
+落點設計（CI 寫不到 Jay 本機）：
+- `--out-dir` 指定輸出目錄。CI 傳 repo 內 data/alerts/（隨 commit 留痕）；
+  本機跑預設 ~/Documents/FLUX/Inbox/agent-alert/（沿用既有 agent-alert 機制）。
+- 格式沿用 FLUX agent-alert markdown（H1 標題 + 條列脈絡），非 JSON，方便人讀。
+
+用法（CI failure step）：
+    python scripts/notify_failure.py \
+        --reason "fetch 401" --run-url "$RUN_URL" \
+        --state data/watcher_state.json --out-dir data/alerts
+
+退出碼永遠 0（告警本身不該再讓 job 連鎖失敗）。
+"""
+import argparse
+import os
+import sys
+from datetime import datetime
+
+DEFAULT_FLUX_INBOX = os.path.expanduser("~/Documents/FLUX/Inbox/agent-alert")
+
+
+def days_since_last_success(state_path: str):
+    """回 (last_run_iso, days_int) ；讀不到 state 回 (None, None)。
+
+    watcher_state.json 的 last_run 只在 watcher 成功跑完才更新，
+    故它代表「最後一次成功」。距今天數 = 連續無成功天數的下界。
+    """
+    try:
+        import json
+        with open(state_path, encoding="utf-8") as f:
+            d = json.load(f)
+        last = d.get("last_run")
+        if not last:
+            return None, None
+        delta = datetime.now() - datetime.fromisoformat(last)
+        return last, delta.days
+    except (OSError, ValueError, KeyError):
+        return None, None
+
+
+def build_alert(reason: str, run_url: str, last_run, stale_days_actual,
+                stale_threshold: int):
+    """組 agent-alert markdown 字串。回 (filename, content, is_high)。"""
+    today = datetime.now().strftime("%Y-%m-%d")
+    is_high = stale_days_actual is not None and stale_days_actual >= stale_threshold
+    sev = "high（連續多日無成功）" if is_high else "中（單日失敗，可能間歇）"
+
+    lines = [
+        f"# gov-bid-watch watcher 失敗 | {today}",
+        "",
+        f"- 嚴重度：{sev}",
+        f"- 失敗原因：{reason}",
+    ]
+    if run_url:
+        lines.append(f"- 失敗 run：{run_url}")
+    if last_run:
+        lines.append(f"- 上次成功：{last_run}（距今 {stale_days_actual} 天）")
+    else:
+        lines.append("- 上次成功：無法判讀 watcher_state（state 缺失或損壞）")
+    lines += [
+        "",
+        "## 怎麼處理",
+    ]
+    if is_high:
+        lines += [
+            f"- ⚠️ 已連續 ≥ {stale_threshold} 天無成功 run，**非間歇抖動**，需人工介入：",
+            "  - 查 TwinkleAI key 是否仍有效 / 配額是否耗盡（裸 401 通常是閘道，JSON-RPC error 才是 key）。",
+            "  - 必要時對外聯絡 TwinkleAI 或更換資料源。",
+        ]
+    else:
+        lines += [
+            "- 單日失敗。fetch 已內建 retry（401/5xx/timeout 指數 backoff 5 次），",
+            "  仍失敗代表閘道持續抖動或 retry 用盡 → 觀察隔日是否自動恢復。",
+            f"- 若連續 ≥ {stale_threshold} 天無成功，本告警會自動升級為 high。",
+        ]
+    content = "\n".join(lines) + "\n"
+    fname = f"{today}-gov-bid-watch-watcher-fail.md"
+    return fname, content, is_high
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reason", required=True, help="失敗原因摘要")
+    ap.add_argument("--run-url", default="", help="GitHub Actions run URL")
+    ap.add_argument("--state", default="data/watcher_state.json")
+    ap.add_argument("--out-dir", default=DEFAULT_FLUX_INBOX,
+                    help="alert 輸出目錄（CI 傳 data/alerts；本機預設 FLUX Inbox）")
+    ap.add_argument("--stale-days", type=int, default=3,
+                    help="距上次成功 ≥ N 天 → 升級 high")
+    args = ap.parse_args()
+
+    last_run, stale = days_since_last_success(args.state)
+    fname, content, is_high = build_alert(
+        args.reason, args.run_url, last_run, stale, args.stale_days)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    path = os.path.join(args.out_dir, fname)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    sev = "HIGH" if is_high else "MID"
+    print(f"[notify_failure:{sev}] -> {path}", file=sys.stderr)
+    print(f"::warning::watcher 失敗告警已寫入 {path}（{sev}）", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_fetch_pcc_retry.py
+++ b/tests/test_fetch_pcc_retry.py
@@ -1,0 +1,103 @@
+"""fetch_pcc retry 行為測試：401/5xx/timeout 重試、永久錯不重試、用盡上限放棄。
+
+不打真 TwinkleAI；mock MCP.s.post 控制回應序列。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import fetch_pcc  # noqa: E402
+from fetch_pcc import MCP, RETRY_STATUS, TransientHTTPError  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch):
+    """把 tenacity 的 wait 改 0，避免測試真的 sleep 指數秒數。
+
+    @retry 包好後 MCP._post.retry 是 Retrying 物件，直接改它的 wait 即可，
+    不需重包 decorator。"""
+    from tenacity import wait_none
+    monkeypatch.setattr(MCP._post.retry, "wait", wait_none())
+
+
+def _resp(status, text="", headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    r.headers = headers or {}
+    return r
+
+
+def _mcp_no_init():
+    """建一個略過 __init__（不發 initialize）的 MCP，方便單測 _post。"""
+    m = MCP.__new__(MCP)
+    m.s = MagicMock()
+    m.h = {}
+    m._id = 0
+    return m
+
+
+def _data_resp():
+    return _resp(200, text='data: {"jsonrpc":"2.0","id":1,"result":{}}\n')
+
+
+def test_retry_recovers_after_intermittent_401():
+    """前兩次 401（裸 nginx 閘道抖動），第三次成功 → 不該 raise。"""
+    m = _mcp_no_init()
+    nginx401 = _resp(401, "<html><head><title>401 Authorization Required</title></head></html>")
+    m.s.post.side_effect = [nginx401, nginx401, _data_resp()]
+    out = m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert m.s.post.call_count == 3
+    assert isinstance(out, list)
+
+
+def test_retry_recovers_after_503():
+    m = _mcp_no_init()
+    m.s.post.side_effect = [_resp(503, "bad gateway"), _data_resp()]
+    m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert m.s.post.call_count == 2
+
+
+def test_retry_recovers_after_timeout():
+    m = _mcp_no_init()
+    m.s.post.side_effect = [requests.Timeout("slow"), _data_resp()]
+    m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert m.s.post.call_count == 2
+
+
+def test_retry_exhausts_then_raises_transient():
+    """持續 401 → retry 用盡（5 次嘗試）→ 最終 raise TransientHTTPError（reraise）。"""
+    m = _mcp_no_init()
+    m.s.post.side_effect = [_resp(401, "nginx")] * 10
+    with pytest.raises(TransientHTTPError):
+        m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert m.s.post.call_count == 5  # stop_after_attempt(5)
+
+
+def test_permanent_error_not_retried():
+    """400（session 錯，非暫時性）→ 不重試，第一次就 raise RuntimeError。"""
+    m = _mcp_no_init()
+    m.s.post.side_effect = [_resp(400, "Missing session ID")]
+    with pytest.raises(RuntimeError) as e:
+        m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert not isinstance(e.value, TransientHTTPError)
+    assert m.s.post.call_count == 1
+
+
+def test_403_permanent_not_retried():
+    m = _mcp_no_init()
+    m.s.post.side_effect = [_resp(403, "forbidden")]
+    with pytest.raises(RuntimeError):
+        m._post({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert m.s.post.call_count == 1
+
+
+def test_retry_status_set_covers_gateway_codes():
+    assert {401, 429, 500, 502, 503, 504} <= RETRY_STATUS
+    assert 400 not in RETRY_STATUS
+    assert 403 not in RETRY_STATUS

--- a/tests/test_notify_failure.py
+++ b/tests/test_notify_failure.py
@@ -17,28 +17,49 @@ def _write_state(tmp_path, last_run):
 
 def test_days_since_last_success_recent(tmp_path):
     last = (datetime.now() - timedelta(days=1)).isoformat(timespec="seconds")
-    last_run, days = days_since_last_success(_write_state(tmp_path, last))
+    last_run, days, err = days_since_last_success(_write_state(tmp_path, last))
     assert days == 1
     assert last_run == last
+    assert err is None
 
 
 def test_days_since_last_success_missing_file(tmp_path):
-    last_run, days = days_since_last_success(str(tmp_path / "nope.json"))
+    last_run, days, err = days_since_last_success(str(tmp_path / "nope.json"))
     assert last_run is None and days is None
+    assert err == "missing"
 
 
 def test_days_since_last_success_no_last_run(tmp_path):
     p = tmp_path / "s.json"
     p.write_text(json.dumps({"runs": []}), encoding="utf-8")
-    last_run, days = days_since_last_success(str(p))
+    last_run, days, err = days_since_last_success(str(p))
     assert last_run is None and days is None
+    assert err == "no_last_run"
+
+
+def test_days_since_last_success_corrupt_json(tmp_path):
+    """state JSON 壞掉 → 標 corrupt（不可讀，不能假裝沒事）。"""
+    p = tmp_path / "bad.json"
+    p.write_text("{ this is not json", encoding="utf-8")
+    last_run, days, err = days_since_last_success(str(p))
+    assert last_run is None and days is None
+    assert err == "corrupt"
+
+
+def test_days_since_last_success_unparseable_timestamp(tmp_path):
+    """有 last_run 但時間格式壞 → 標 unparseable。"""
+    p = tmp_path / "u.json"
+    p.write_text(json.dumps({"last_run": "not-a-timestamp"}), encoding="utf-8")
+    last_run, days, err = days_since_last_success(str(p))
+    assert last_run is None and days is None
+    assert err == "unparseable"
 
 
 def test_alert_mid_when_fresh():
     """距上次成功 1 天 → 中度，不升級。"""
-    fname, content, is_high = build_alert(
+    fname, content, severity = build_alert(
         "fetch 401", "http://run/1", "2026-06-22T05:00:00", 1, stale_threshold=3)
-    assert is_high is False
+    assert severity == "mid"
     assert "中（單日失敗" in content
     assert fname.endswith("-gov-bid-watch-watcher-fail.md")
     assert "fetch 401" in content
@@ -46,19 +67,55 @@ def test_alert_mid_when_fresh():
 
 def test_alert_high_when_stale():
     """距上次成功 4 天（≥ 閾值 3）→ 升級 high + 人工介入文案。"""
-    fname, content, is_high = build_alert(
+    fname, content, severity = build_alert(
         "fetch 401", "http://run/1", "2026-06-19T05:00:00", 4, stale_threshold=3)
-    assert is_high is True
+    assert severity == "high"
     assert "high" in content
     assert "人工介入" in content
 
 
-def test_alert_high_when_state_unreadable():
-    """state 讀不到（days=None）→ 不誤判成 high（保守不升級）。"""
-    _, content, is_high = build_alert(
-        "boom", "", None, None, stale_threshold=3)
-    assert is_high is False
+# ── regression（codex medium）：不可讀 state 必須升級，不准保守停 mid ──
+# 舊行為（已修）：state 壞/缺 → days=None → 只標 mid，state 壞掉後永遠停 medium。
+# 新行為：missing/corrupt/unparseable → critical（unknown_last_success）、
+#        no_last_run → high。任一情況都不得是 mid。
+
+def test_alert_critical_when_state_missing():
+    """state 檔缺失 → critical，不准降級成 mid。"""
+    _, content, severity = build_alert(
+        "boom", "", None, None, stale_threshold=3, state_error="missing")
+    assert severity == "critical"
+    assert "unknown_last_success" in content
     assert "無法判讀" in content
+
+
+def test_alert_critical_when_state_corrupt():
+    """state JSON 損壞 → critical。"""
+    _, content, severity = build_alert(
+        "boom", "", None, None, stale_threshold=3, state_error="corrupt")
+    assert severity == "critical"
+    assert "損壞" in content
+
+
+def test_alert_critical_when_timestamp_unparseable():
+    """last_run 時間格式壞 → critical。"""
+    _, _, severity = build_alert(
+        "boom", "", None, None, stale_threshold=3, state_error="unparseable")
+    assert severity == "critical"
+
+
+def test_alert_high_when_never_succeeded():
+    """state 可讀但從沒成功（no_last_run）→ high，不是 mid。"""
+    _, _, severity = build_alert(
+        "boom", "", None, None, stale_threshold=3, state_error="no_last_run")
+    assert severity == "high"
+
+
+def test_unreadable_state_never_mid():
+    """守門 regression：任何不可讀 state 都不會是 mid（防回歸到舊保守行為）。"""
+    for err in ("missing", "corrupt", "unparseable", "no_last_run"):
+        _, _, severity = build_alert(
+            "x", "", None, None, stale_threshold=3, state_error=err)
+        assert severity != "mid", f"state_error={err} 不該停在 mid"
 
 
 def test_main_writes_file(tmp_path, monkeypatch):

--- a/tests/test_notify_failure.py
+++ b/tests/test_notify_failure.py
@@ -1,0 +1,78 @@
+"""notify_failure：失敗告警 markdown 寫入 + 心跳升級邏輯。"""
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from notify_failure import build_alert, days_since_last_success  # noqa: E402
+
+
+def _write_state(tmp_path, last_run):
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps({"last_run": last_run, "runs": []}), encoding="utf-8")
+    return str(p)
+
+
+def test_days_since_last_success_recent(tmp_path):
+    last = (datetime.now() - timedelta(days=1)).isoformat(timespec="seconds")
+    last_run, days = days_since_last_success(_write_state(tmp_path, last))
+    assert days == 1
+    assert last_run == last
+
+
+def test_days_since_last_success_missing_file(tmp_path):
+    last_run, days = days_since_last_success(str(tmp_path / "nope.json"))
+    assert last_run is None and days is None
+
+
+def test_days_since_last_success_no_last_run(tmp_path):
+    p = tmp_path / "s.json"
+    p.write_text(json.dumps({"runs": []}), encoding="utf-8")
+    last_run, days = days_since_last_success(str(p))
+    assert last_run is None and days is None
+
+
+def test_alert_mid_when_fresh():
+    """距上次成功 1 天 → 中度，不升級。"""
+    fname, content, is_high = build_alert(
+        "fetch 401", "http://run/1", "2026-06-22T05:00:00", 1, stale_threshold=3)
+    assert is_high is False
+    assert "中（單日失敗" in content
+    assert fname.endswith("-gov-bid-watch-watcher-fail.md")
+    assert "fetch 401" in content
+
+
+def test_alert_high_when_stale():
+    """距上次成功 4 天（≥ 閾值 3）→ 升級 high + 人工介入文案。"""
+    fname, content, is_high = build_alert(
+        "fetch 401", "http://run/1", "2026-06-19T05:00:00", 4, stale_threshold=3)
+    assert is_high is True
+    assert "high" in content
+    assert "人工介入" in content
+
+
+def test_alert_high_when_state_unreadable():
+    """state 讀不到（days=None）→ 不誤判成 high（保守不升級）。"""
+    _, content, is_high = build_alert(
+        "boom", "", None, None, stale_threshold=3)
+    assert is_high is False
+    assert "無法判讀" in content
+
+
+def test_main_writes_file(tmp_path, monkeypatch):
+    """end-to-end：跑 main 把 alert md 寫進 out-dir。"""
+    import notify_failure
+    last = (datetime.now() - timedelta(days=1)).isoformat(timespec="seconds")
+    state = _write_state(tmp_path, last)
+    out = tmp_path / "alerts"
+    monkeypatch.setattr(sys, "argv", [
+        "notify_failure.py", "--reason", "fetch 401",
+        "--run-url", "http://run/9", "--state", state, "--out-dir", str(out),
+    ])
+    rc = notify_failure.main()
+    assert rc == 0
+    files = list(out.glob("*-gov-bid-watch-watcher-fail.md"))
+    assert len(files) == 1
+    assert "fetch 401" in files[0].read_text(encoding="utf-8")


### PR DESCRIPTION
解決 #17：watcher 從「~50% 間歇失敗且靜默」→「失敗自動重試 + 真失敗主動通知」。

## 改了什麼
- **retry**（`scripts/fetch_pcc.py`）：`MCP._post` 用 tenacity 包指數 backoff（1→2→4→8s，5 次上限）。**區分暫時/永久錯**——401/429/5xx/timeout/connection → `TransientHTTPError` 觸發 retry；400/403/app 層 JSON-RPC error → `RuntimeError` 立即失敗不盲重試。`tenacity` 顯式進 requirements.txt（原只靠 streamlit 傳遞性帶入）。
- **失敗告警**（新 `scripts/notify_failure.py`）：watcher 失敗寫 agent-alert markdown，`--out-dir` 參數化落點——CI 落 repo `data/alerts/`、本機落 FLUX Inbox。心跳：讀 `watcher_state.json` 的 last_run，連續 ≥3 天無成功升級 high。
- **workflow**（`daily-watcher.yml`）：加 `if: failure()` 告警 step；commit step 改 `if: always()` 讓告警 md 留痕。
- **ADR** `docs/adr/0002-watcher-retry-and-failure-alert.md`：401 判讀 + 4 個架構決策。

## 401 根因
失敗 run 回**裸 nginx 401 HTML**（非 MCP app JSON-RPC 認證錯）→ 閘道間歇抖動非 key 死掉（多日成功證明 key 有效）。故 retry 對症，屬可控範圍、不觸發對外停點。

## 怎麼驗的
- 新增 14 測試：retry 序列（401×2 後成功 / 503 / timeout / 用盡 5 次 reraise / 400·403 永久錯不重試）+ 告警心跳（中度/升級/state 損壞/end-to-end 寫檔）。
- `pytest` 全綠：**86 passed, 5 xfailed**（xfail 為既有）。
- 手動 dispatch 驗證結果見 #17 comment。

## 邊界
動手只到 PR；merge / 部署 / 改 secret 留人。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### 2026-06-23 已修 codex 兩發現（重審用）
- **[high] push 失敗不再隱形**：`daily-watcher.yml` commit step 去掉 `git push || true`，改 rebase 重試 3 次仍失敗則 `exit 1` 紅燈。
- **[medium] 不可讀 state 升級告警**：`notify_failure.py` 區分 missing/corrupt/unparseable/no_last_run，前三者升 critical（unknown_last_success）、no_last_run 升 high，永不停 mid；刪寫死錯誤行為的舊測試、加 6 個 regression。
- 測試：92 passed, 5 xfailed（原 86+5）。
- ⚠️ 範圍外：dispatch 成功（TWINKLE_API_KEY）仍待 Jay，本次未碰 secret。
