### PR TITLE
harness P1：①Ship-PR-Until-Green + ④獨立驗收（試點裝進 gov-bid-watch）

### DIFF
--- a/.claude/harness/INDEPENDENT-VERIFIER.md
+++ b/.claude/harness/INDEPENDENT-VERIFIER.md
@@ -1,0 +1,38 @@
+# ④ Independent Verifier — 守則與分工
+
+> spec: `docs/specs/ship-pr-until-green-harness.md`（sw-factory）§3。
+> 與 `independent-verify.sh` 配套：腳本做機械可驗的半（重跑測試 + 撈 CI），本檔定誰來驗、驗什麼、怎麼回。
+
+## 鐵則（違反＝驗收無效）
+
+1. **換 session / 換 agent**：必在【另起乾淨 session】跑，由本部 `qa-automation-architect` 為主。
+   **不**延續①的開發 session、**不**由寫 code 的同一 agent 自驗。建者與盲點共用假設。
+2. **錨非 LLM 信號**：判定錨在 build 成功 / pytest 綠 / CI conclusion=success / AC 對照表全勾，
+   不是「另一個 agent 說 OK」。evaluator 背後要有 ground-truth test suite 兜底。
+3. **驗不過＝退回①，不就地放水**：找到的洞寫回測試案例（成為 failing 信號），退回①loop 修綠，
+   再驗（驗者與建者保持不同 session）。
+
+## 驗什麼（四步）
+
+| 步 | 內容 | 錨 |
+|----|------|----|
+| (a) | 本機重跑 build + check + 全測試（對齊 VERIFY.md），確認 CI 綠非環境僥倖 | pytest exit 0 |
+| (b) | 撈 PR 的遠端 CI 結論 | gh pr checks = pass |
+| (c) | 讀 spec 的 AC，逐條確認有對應測試且涵蓋（填下方對照表） | AC↔test 對照全勾 |
+| (d) | 探索測試：邊界 / 亂打輸入 / 不照 happy path，找①沒想到的洞 | 洞數（>0 須補測退回①）|
+
+## AC ↔ 測試對照表（驗收時填）
+
+| AC | 對應測試 | 涵蓋？ | 備註 |
+|----|---------|--------|------|
+| （逐條填 spec 的 AC） | | ☐ | |
+
+## 用 `/code-review` 還是獨立 agent
+
+- **獨立 agent 為主**（`qa-automation-architect`）：要跑 deliverable + 探索測試，純讀 diff 抓不到 runtime 盲點。
+- `/code-review` 為輔：可在本 session 內當靜態審查一道，不取代「跑起來驗」。
+
+## 驗過之後
+
+在 PR 留「獨立驗收已過」記錄（驗了什麼 / 補了哪些案例 / 結論），PR 轉 ready-for-human-review。
+到此 loop 結束，**交人 review + merge**。merge 永遠人按。

--- a/.claude/harness/README.md
+++ b/.claude/harness/README.md
@@ -38,15 +38,27 @@ bash .claude/harness/independent-verify.sh <PR_NUMBER>
 
 ## 三層終止（錨客觀信號，spec §2.2）
 
-| 層 | 條件 | 預設 | 行為 |
+| 層 | 條件 | 預設 | 行為 / exit |
 |----|------|------|------|
-| 達標停 | 本機 pytest 綠 + 遠端 CI success | — | 進 ④ |
-| 保險絲 | iter > `MAX_ITER` / 牆鐘 > `MAX_WALL` | 8 / 3600s | 停 + 回報人 |
-| 無進展停 | 連續 `NO_PROGRESS_N` 輪紅項分數沒降 | 3 | 停 + 回報人 |
+| 達標停 | 本機 pytest 綠 **且** 遠端 CI success（CI run 的 commit SHA 必須==本輪 HEAD）| — | exit 0 → 進 ④ |
+| 保險絲（迭代）| 已完成 `MAX_ITER` 輪後再呼叫即停（**最多跑 MAX_ITER 輪**；第 8 輪是最後一輪，第 9 次呼叫 STOP）| 8 | exit 3，停 + 回報人 |
+| 保險絲（牆鐘）| 牆鐘 > `MAX_WALL` | 3600s | exit 3 |
+| 無進展停 | 連續 `NO_PROGRESS_N` 輪紅項分數沒降 | 3 | exit 3 |
+| 缺客觀 CI 信號 | push 後找不到本輪 SHA 對應的 CI run / gh 不可用 / 逾時 | — | **exit 3 STOP**（不可當綠 exit 0）|
+| 本機綠但 CI 紅 / push 失敗 | — | — | exit 1 FAIL，回去改 |
+
+> ⚠️ **CI 不可用 ≠ 達標**（codex#1）：缺遠端 CI success 信號一律 STOP，禁退化成本機自評放行。
+> ⚠️ **CI run 必須對齊本輪 commit**（codex#2）：runner 只認 `headSha==本輪 HEAD` 的 run，不拿 branch 舊 run 充當成功；push 失敗即 FAIL。
 
 `TOKEN_BUDGET` 試點期先收 baseline 實測（agent 回填），再定預設。覆寫：`MAX_ITER=N bash ship-pr-loop.sh`。
+CI 輪詢覆寫：`CI_POLL_TRIES` / `CI_POLL_SLEEP`（預設 60 × 10s）。
 
 ## 不可逆邊界（鐵則，spec §2.3）
 
 runner 只做可逆動作：append commit / push feature 分支 / 開 PR。
-**禁** amend / rebase / force-push / push main / **auto-merge**——runner 偵測在受保護分支會 exit 2。merge 永遠人按。
+**禁** amend / rebase / force-push / push main / **auto-merge**。
+
+**受保護分支守門＝白名單制**（codex#3）：
+- 只有命中 `ALLOWED_FEATURE_RE`（預設 `feat|fix|chore|docs|test|refactor|perf|ci|build|style` 開頭）的 feature 分支可被 loop 動作。
+- `PROTECTED_RE`（`main|master|develop|release*|prod*|production*|hotfix*`）為第一層硬擋，與白名單**獨立兩層**——放寬任一層，另一層仍把關，故 env 無法繞過放行受保護分支。
+- 非 feature 分支 / 受保護分支 → exit 2 拒絕。merge 永遠人按。

--- a/.claude/harness/README.md
+++ b/.claude/harness/README.md
@@ -1,0 +1,52 @@
+# harness P1 — Ship-PR-Until-Green + Independent Verifier
+
+> spec: `docs/specs/ship-pr-until-green-harness.md`（hyweb-sw-factory）。
+> 試點裝進 gov-bid-watch。本目錄＝harness 落地件，把「跑 CI → 看紅綠 → 紅就修」的來回交給機器，
+> 跑到 CI 綠才叫人，且綠了還要換 session 獨立再驗一遍，人留下的只有 review + 按 merge。
+
+## 件清單
+
+| 檔 | 角色 |
+|----|------|
+| `ship-pr-loop.sh` | ① Ship-PR-Until-Green runner：每輪跑客觀信號 → push → 等 CI，判三層終止 / 保險絲 / 不可逆邊界 |
+| `independent-verify.sh` + `INDEPENDENT-VERIFIER.md` | ④ 獨立驗收：換 session 重驗，錨非 LLM 信號 |
+| `../hooks/pre-commit-gate` | ② commit 前三閘（message / diff≤150 / 測試綠），loop step 3 用（沿用 sw-factory，不重造）|
+| `../../VERIFY.md` | 測試指令單一來源，三方對齊 |
+| `.state/` | loop 跨輪狀態（iter / 分數歷史 / 起始時間），gitignore |
+
+## 怎麼跑（agent 視角）
+
+前提（spec §5，缺任一不套）：CI 在 PR→main 跑全測試（`.github/workflows/ci.yml`）｜AI-owned 無真人並發｜spec AC 可測｜測試基建到位。
+
+```bash
+# 0. 隔離工作樹 + feature 分支（撞車防護，gov-bid-watch 有每日 data-commit）
+git worktree add -b feat/xxx <worktree-path> origin/main
+export PRECOMMIT_TEST_CMD="python3 -m pytest -q"  # 啟用 commit 前閘3
+
+# 1. ① loop：agent 改一小步 code → 跑一輪 runner，依回報決定下一步
+bash .claude/harness/ship-pr-loop.sh
+#   exit 0 = PASS（達標，進 ④）   exit 1 = FAIL（紅，回去改再跑）   exit 3 = STOP（保險絲/無進展，回報人）
+bash .claude/harness/ship-pr-loop.sh --status   # 看額度
+
+# 2. 達標後開 PR（draft 或 ready），人 merge 前最後一道
+gh pr create ...
+
+# 3. ④ 獨立驗收：【另起乾淨 session】派 qa-automation-architect 跑
+bash .claude/harness/independent-verify.sh <PR_NUMBER>
+#   驗過 → PR 留「獨立驗收已過」→ 交人 review + merge
+```
+
+## 三層終止（錨客觀信號，spec §2.2）
+
+| 層 | 條件 | 預設 | 行為 |
+|----|------|------|------|
+| 達標停 | 本機 pytest 綠 + 遠端 CI success | — | 進 ④ |
+| 保險絲 | iter > `MAX_ITER` / 牆鐘 > `MAX_WALL` | 8 / 3600s | 停 + 回報人 |
+| 無進展停 | 連續 `NO_PROGRESS_N` 輪紅項分數沒降 | 3 | 停 + 回報人 |
+
+`TOKEN_BUDGET` 試點期先收 baseline 實測（agent 回填），再定預設。覆寫：`MAX_ITER=N bash ship-pr-loop.sh`。
+
+## 不可逆邊界（鐵則，spec §2.3）
+
+runner 只做可逆動作：append commit / push feature 分支 / 開 PR。
+**禁** amend / rebase / force-push / push main / **auto-merge**——runner 偵測在受保護分支會 exit 2。merge 永遠人按。

--- a/.claude/harness/independent-verify.sh
+++ b/.claude/harness/independent-verify.sh
@@ -17,7 +17,7 @@
 #   bash .claude/harness/independent-verify.sh <PR_NUMBER>
 #   bash .claude/harness/independent-verify.sh        # 不帶 PR 號＝只重跑本機，不撈 CI
 
-set -uo pipefail
+set -euo pipefail
 : "${TEST_CMD:=python3 -m pytest -q}"
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PR="${1:-}"
@@ -28,9 +28,16 @@ say "branch: $(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)  PR: ${PR
 say ""
 
 # ── (a) 重跑 build + 全測試（確認 CI 綠非環境僥倖）──
+# codex 建議：不用 eval（白名單前綴 + 陣列分詞）；/tmp 檔用 mktemp 防並發/搶佔。
 say "▶ (a) 本機重跑全測試：$TEST_CMD"
-LOG="/tmp/independent-verify-test.log"
-if ( cd "$ROOT" && eval "$TEST_CMD" ) >"$LOG" 2>&1; then
+LOG="$(mktemp -t independent-verify-test.XXXXXX)"
+trap 'rm -f "$LOG"' EXIT
+read -ra _TEST_ARGV <<<"$TEST_CMD"
+case "${_TEST_ARGV[0]:-}" in
+  python|python3|pytest) ;;
+  *) say "🔴 TEST_CMD 首字不在白名單(python/python3/pytest)，拒絕執行。"; exit 2 ;;
+esac
+if ( cd "$ROOT" && "${_TEST_ARGV[@]}" ) >"$LOG" 2>&1; then
   LOCAL_PASS=1; say "   ✅ 本機測試全綠"
 else
   LOCAL_PASS=0; say "   🔴 本機測試紅 → 驗收不過，退回①loop（CI 綠是僥倖）"
@@ -38,17 +45,33 @@ else
 fi
 
 # ── (b) 撈遠端 CI 結論（非 LLM 錨信號）──
-CI_STATE="skipped"
+# codex#6：原本只看 LOCAL_PASS、忽略 CI_STATE。
+#   獨立驗收的達標鐵則（spec §3.3）＝【本機綠 AND 遠端 required CI success】。
+#   CI_PASS 三態：1=全綠且至少一個 check；0=有 fail；2=未知(無 PR / gh 不可用 / pending / 無 check)。
+CI_PASS=2
+CI_STATE="skipped(無 PR 號或 gh 不可用)"
 if [ -n "$PR" ] && command -v gh >/dev/null 2>&1; then
   say "▶ (b) 撈 PR #$PR 的 CI 結論"
-  CI_STATE="$(gh pr checks "$PR" 2>/dev/null | awk '{print $2}' | sort -u | tr '\n' ',')"
-  say "   CI checks: ${CI_STATE:-<none>}"
+  # gh pr checks 第二欄＝狀態(pass/fail/pending/skipping)。逐行判定。
+  CHECKS="$(gh pr checks "$PR" 2>/dev/null | awk 'NF{print $2}')"
+  CI_STATE="$(printf '%s' "$CHECKS" | sort | uniq -c | tr '\n' ',' )"
+  if [ -z "$CHECKS" ]; then
+    CI_PASS=2; CI_STATE="無 CI check（CI 未啟用或未觸發）"
+  elif printf '%s\n' "$CHECKS" | grep -qiE '^(fail|failure|error)'; then
+    CI_PASS=0
+  elif printf '%s\n' "$CHECKS" | grep -qiE '^(pending|in_progress|queued|waiting)'; then
+    CI_PASS=2; CI_STATE="${CI_STATE} (尚有 pending，未定論)"
+  else
+    # 全部 pass/skipping 且至少有一個 check
+    CI_PASS=1
+  fi
+  say "   CI checks: ${CI_STATE}"
 fi
 
 say ""
 say "── 機械驗收結果 ──"
 say "本機測試全綠     : $([ "$LOCAL_PASS" = 1 ] && echo PASS || echo FAIL)"
-say "遠端 CI          : ${CI_STATE}"
+say "遠端 CI          : $(case $CI_PASS in 1) echo PASS;; 0) echo FAIL;; *) echo UNKNOWN;; esac) (${CI_STATE})"
 say ""
 say "下一步（qa-automation-architect 在【本 session】續做，非開發 session）："
 say "  1. 讀 spec 的 AC，逐條確認有對應測試且涵蓋（填 AC 對照表）"
@@ -56,5 +79,28 @@ say "  2. 探索測試：邊界 / 亂打輸入 / 不照 happy path（找①沒�
 say "  3. 找到洞 → 寫回測試案例（變 failing 信號）→ 退回①loop 修綠 → 再驗"
 say "  4. 全綠 + AC 全勾 + 探索無洞 → 在 PR 留『獨立驗收已過』記錄 → 轉交人 review"
 say ""
-[ "$LOCAL_PASS" = 1 ] || exit 1
+
+# codex#6：機械驗收門＝本機綠 AND 遠端 CI success，缺一不可 exit 0。
+if [ "$LOCAL_PASS" != 1 ]; then
+  say "🔴 機械驗收不過：本機測試紅。退回①loop。"
+  exit 1
+fi
+if [ "$CI_PASS" = 0 ]; then
+  say "🔴 機械驗收不過：遠端 CI 紅。退回①loop。"
+  exit 1
+fi
+if [ "$CI_PASS" != 1 ]; then
+  # 帶了 PR 卻拿不到明確 CI success（pending / 無 check / gh 不可用）＝無客觀遠端信號，不可放行
+  if [ -n "$PR" ]; then
+    say "🛑 機械驗收未定論：本機綠但遠端 CI 非 success（${CI_STATE}）。"
+    say "   獨立驗收鐵則須【本機綠 + 遠端 CI success】；缺 CI 信號不可判過。等 CI 出結論再驗。"
+    exit 2
+  fi
+  # 未帶 PR 號＝只做本機半，明示這不是完整驗收，仍以非 0 退出避免被誤當「過」
+  say "🛑 機械驗收半套：未提供 PR 號，只重跑了本機（無遠端 CI 信號）。"
+  say "   完整獨立驗收須帶 PR 號錨遠端 CI：bash $0 <PR_NUMBER>"
+  exit 2
+fi
+
+say "🟢 機械驗收通過：本機綠 + 遠端 CI success。交 qa-automation-architect 續做探索測試/AC 對照。"
 exit 0

--- a/.claude/harness/independent-verify.sh
+++ b/.claude/harness/independent-verify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# independent-verify.sh — ④ Independent Verifier（harness P1）
+#
+# spec: docs/specs/ship-pr-until-green-harness.md（sw-factory）§3
+# 定位：①loop 跑到綠之後，【換一個乾淨 session / 獨立 agent】重驗一遍。
+#   CI 綠只代表「建者想到要寫的測試都過了」，不代表「沒有他沒想到的洞」。
+#   建者與自身盲點共用同一套假設（FLUX feedback_builder_not_self_verify）。
+#
+# 錨點鐵則（§3.3）：判定錨在【非 LLM 信號】——build 成功 / pytest 綠 / CI conclusion=success /
+#   AC 對照表全勾，不是「另一個 agent 說 OK」。
+#
+# 此腳本做機械可驗的那半（重跑測試 + 撈 CI 結論），輸出一份「verifier 報告骨架」；
+# 探索測試 / AC 逐條對照 / 補洞 由 qa-automation-architect agent 在【另起 session】填。
+# 守則與分工見同目錄 INDEPENDENT-VERIFIER.md。
+#
+# 用法（必在另起 session 跑，非①的開發 session）：
+#   bash .claude/harness/independent-verify.sh <PR_NUMBER>
+#   bash .claude/harness/independent-verify.sh        # 不帶 PR 號＝只重跑本機，不撈 CI
+
+set -uo pipefail
+: "${TEST_CMD:=python3 -m pytest -q}"
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PR="${1:-}"
+say() { printf '%s\n' "$*" >&2; }
+
+say "═══ ④ Independent Verifier ═══"
+say "branch: $(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)  PR: ${PR:-<none>}"
+say ""
+
+# ── (a) 重跑 build + 全測試（確認 CI 綠非環境僥倖）──
+say "▶ (a) 本機重跑全測試：$TEST_CMD"
+LOG="/tmp/independent-verify-test.log"
+if ( cd "$ROOT" && eval "$TEST_CMD" ) >"$LOG" 2>&1; then
+  LOCAL_PASS=1; say "   ✅ 本機測試全綠"
+else
+  LOCAL_PASS=0; say "   🔴 本機測試紅 → 驗收不過，退回①loop（CI 綠是僥倖）"
+  tail -n 15 "$LOG" >&2
+fi
+
+# ── (b) 撈遠端 CI 結論（非 LLM 錨信號）──
+CI_STATE="skipped"
+if [ -n "$PR" ] && command -v gh >/dev/null 2>&1; then
+  say "▶ (b) 撈 PR #$PR 的 CI 結論"
+  CI_STATE="$(gh pr checks "$PR" 2>/dev/null | awk '{print $2}' | sort -u | tr '\n' ',')"
+  say "   CI checks: ${CI_STATE:-<none>}"
+fi
+
+say ""
+say "── 機械驗收結果 ──"
+say "本機測試全綠     : $([ "$LOCAL_PASS" = 1 ] && echo PASS || echo FAIL)"
+say "遠端 CI          : ${CI_STATE}"
+say ""
+say "下一步（qa-automation-architect 在【本 session】續做，非開發 session）："
+say "  1. 讀 spec 的 AC，逐條確認有對應測試且涵蓋（填 AC 對照表）"
+say "  2. 探索測試：邊界 / 亂打輸入 / 不照 happy path（找①沒想到的洞）"
+say "  3. 找到洞 → 寫回測試案例（變 failing 信號）→ 退回①loop 修綠 → 再驗"
+say "  4. 全綠 + AC 全勾 + 探索無洞 → 在 PR 留『獨立驗收已過』記錄 → 轉交人 review"
+say ""
+[ "$LOCAL_PASS" = 1 ] || exit 1
+exit 0

--- a/.claude/harness/independent-verify.sh
+++ b/.claude/harness/independent-verify.sh
@@ -47,7 +47,10 @@ fi
 # ── (b) 撈遠端 CI 結論（非 LLM 錨信號）──
 # codex#6：原本只看 LOCAL_PASS、忽略 CI_STATE。
 #   獨立驗收的達標鐵則（spec §3.3）＝【本機綠 AND 遠端 required CI success】。
-#   CI_PASS 三態：1=全綠且至少一個 check；0=有 fail；2=未知(無 PR / gh 不可用 / pending / 無 check)。
+# codex#4（第 2 輪）：原本「全部 pass/skipping」一律當 PASS → 全 skipping/neutral
+#   （什麼都沒真跑）也被當綠＝假綠。改：必須【至少一個 check 真的 pass】、且【無 fail、無 pending】
+#   才算 success；全 skipped/neutral/空 → UNKNOWN(2)，不可 PASS。
+#   CI_PASS 三態：1=至少一個真 pass 且無 fail/pending；0=有 fail；2=未知(無 PR/gh 不可用/pending/全 skip/空)。
 CI_PASS=2
 CI_STATE="skipped(無 PR 號或 gh 不可用)"
 if [ -n "$PR" ] && command -v gh >/dev/null 2>&1; then
@@ -61,17 +64,25 @@ if [ -n "$PR" ] && command -v gh >/dev/null 2>&1; then
     CI_PASS=0
   elif printf '%s\n' "$CHECKS" | grep -qiE '^(pending|in_progress|queued|waiting)'; then
     CI_PASS=2; CI_STATE="${CI_STATE} (尚有 pending，未定論)"
-  else
-    # 全部 pass/skipping 且至少有一個 check
+  elif printf '%s\n' "$CHECKS" | grep -qiE '^(pass|success)'; then
+    # 至少一個 check 真的 pass，且（經上面排除）無 fail、無 pending → 真 success。
     CI_PASS=1
+  else
+    # 走到這＝有 check 但沒有任何一個真 pass（全 skipping/neutral/skipped）→ 什麼都沒真驗。
+    CI_PASS=2; CI_STATE="${CI_STATE} (全 skipping/neutral，無任何真 pass → 不可當綠)"
   fi
   say "   CI checks: ${CI_STATE}"
 fi
 
+case "$CI_PASS" in
+  1) CI_LABEL=PASS ;;
+  0) CI_LABEL=FAIL ;;
+  *) CI_LABEL=UNKNOWN ;;
+esac
 say ""
 say "── 機械驗收結果 ──"
 say "本機測試全綠     : $([ "$LOCAL_PASS" = 1 ] && echo PASS || echo FAIL)"
-say "遠端 CI          : $(case $CI_PASS in 1) echo PASS;; 0) echo FAIL;; *) echo UNKNOWN;; esac) (${CI_STATE})"
+say "遠端 CI          : ${CI_LABEL} (${CI_STATE})"
 say ""
 say "下一步（qa-automation-architect 在【本 session】續做，非開發 session）："
 say "  1. 讀 spec 的 AC，逐條確認有對應測試且涵蓋（填 AC 對照表）"

--- a/.claude/harness/report.md
+++ b/.claude/harness/report.md
@@ -84,3 +84,18 @@ runner 自測（子行程餵狀態檔），exit code 契約全符：
 1. ④ 探索測試 + AC 逐條對照：須換乾淨 session 派 qa-automation-architect（建者不自驗）。本 report 只完成機械半。
 2. merge：留 Jay。merge 前主 session 跑 /codex:adversarial-review 跨模型審 PR #20 diff。
 3. ci.yml 已加且 PR #20 實證能跑綠；若要設 main branch protection required check，屬 repo 設定＝人類動作。
+
+## 四點七、CI 紅修復：detached HEAD 環境回歸（2026-06-24）
+
+**症狀**：本機在 `feat/...` 分支 `116 passed`，但 PR #20 的 CI（run 28096163131）pytest **FAIL**。
+
+**根因（#3 修法引入的環境回歸）**：`actions/checkout` 預設 checkout 出來是 **detached HEAD**，`git rev-parse --abbrev-ref HEAD` 回 `HEAD`（非分支名）。#3 新加的 feature 分支白名單守門（`ALLOWED_FEATURE_RE`）命中「`HEAD` 非 feature 分支」→ `guard_irreversible` 在主流程開頭（runner line 204）**exit 2 搶先攔掉**，harness 行為測試（off-by-one / no-progress / local-red / push / ci 三態）全在跑到目標斷言前就被擋紅。本機在 feat/ 分支跑剛好命中白名單所以全綠，遮住了這個洞。
+
+**修法（只動測試、不動 runner）**：問題不在守門邏輯（守門擋 detached HEAD 是正確的——不該在無分支上下文跑不可逆動作），在於**行為測試不該依賴 CI 實際 checkout 的分支**。`tests/test_harness_loop.py` 的 `_run` 一律前置「分支攔截」stub：攔 `rev-parse --abbrev-ref HEAD` 回測試指定分支（行為測試預設 `feat/harness-test`，分支判定測試經 `_run_on_branch(stub_branch=...)` 指定），其餘 git 子命令照舊 delegate 真 git。branch context 由測試明確注入，與 runner 在哪個 checkout 跑無關。
+
+**未動 #3 protected 守門**：本次 diff **只改 `tests/test_harness_loop.py`**，`ship-pr-loop.sh` 一個字沒動 → #3 成果（`readonly PROTECTED_BUILTIN_RE` 內建常數、env 只能 `PROTECTED_EXTRA_RE` 收緊、白名單放寬越不過內建保護）原封保住，protected branch 仍不可被任何 env 組合繞過。
+
+**怎麼證明 detached HEAD 也綠**：worktree 內 `git checkout --detach`（`rev-parse --abbrev-ref HEAD` 確認回 `HEAD`，與 CI 同態）後跑 `pytest`：
+- `tests/test_harness_loop.py`：14 passed（修前同環境 3 failed）。
+- 全 repo：`116 passed, 5 xfailed`，與 feat/ 分支結果一致。
+re-attach 回 feat/ 分支後再跑亦 116 passed，兩態一致。

--- a/.claude/harness/report.md
+++ b/.claude/harness/report.md
@@ -46,6 +46,27 @@ runner 自測（子行程餵狀態檔），exit code 契約全符：
 > TOKEN_BUDGET 結論：本輪是「建 harness + 1 輪達標」混合樣本，不足以定 TOKEN_BUDGET 預設。
 > 建議之後拿 harness 跑 2–3 個「真正多輪修綠」任務，收每輪 token 再定預設。
 
+## 四點五、codex 對抗審查退回修（2026-06-24）
+
+主 session 跑 `/codex:adversarial-review`（GPT-5）審 PR #20，判定退回。根病灶＝harness 不把「遠端 CI 客觀綠」當硬閘，打穿驗收②與「跑到 CI 綠」目標。本輪修以下 5 項（皆有對應回歸測試）：
+
+| # | 漏洞 | 修法 | 驗證測試 |
+|---|------|------|---------|
+| 1 | CI 不可用 / 無 run 時 ci=2，主流程卻寫 pass-local-only 並 exit 0 | ci=2 改 **exit 3 STOP**（缺客觀 CI 信號≠達標，禁當綠放行）| `test_ci_unavailable_stops_not_pass` |
+| 2 | push 失敗被吞；等 CI 抓 branch 最新 run（可能是舊 commit）當成功 | push 失敗即 **exit 1 FAIL**；`wait_remote_ci` 帶本輪 HEAD SHA，只認 `headSha==本輪 SHA` 的 run，找不到→STOP | `test_push_failure_fails`、`test_ci_run_sha_must_match_head` |
+| 3 | 受保護分支守門是可覆寫黑名單（`BRANCH_PREFIX_MAIN` env 可改、不擋 master/release/prod）| 改**白名單制**：只允 `feat/fix/...` 等 feature 分支；`PROTECTED_RE` 硬擋層 + 白名單層兩層獨立，env 無法繞過放行 | `test_protected_branch_hard_block`、`test_non_feature_branch_blocked_by_whitelist`、`test_protected_block_not_bypassable_by_widening_whitelist` |
+| 6 | independent-verify 最後只看 `LOCAL_PASS`、不看 CI 狀態 | 機械驗收門改 **本機綠 AND 遠端 CI success**；CI 有 fail→exit1、pending/無 check/無 PR→exit2、全綠→exit0 | smoke 三態實測（pass→0 / fail→1 / pending→2）|
+| 7 | `MAX_ITER=8` 實際跑到 iter=9 才停（off-by-one）| 迭代上限檢查移到自增**前**用 `-ge`：iter=已完成輪數，達 MAX_ITER 即停＝最多 8 輪；README 對齊 | `test_fuse_max_iter_off_by_one`、`test_max_iter_allows_exactly_n_rounds` |
+
+**一併採納的建議改**：
+- `set -uo`→`set -euo pipefail`，並逐處加固 `set -e` 副作用（`wait_remote_ci || ci=$?` 取回傳碼；TEST_CMD 白名單檢查前移出 command substitution 以免 die 被 subshell 吞）。
+- `eval "$TEST_CMD"` → 白名單前綴（python/python3/pytest）+ `read -ra` 陣列分詞執行，去除注入面（`test_test_cmd_whitelist_rejects_non_python`）。
+- 固定 `/tmp/independent-verify-test.log` → `mktemp` + `trap rm` 清理，去並發搶佔。
+
+**測試補強**：原測試刻意避開的最危險路徑（ci=2 應 STOP / push 失敗應 FAIL / CI run SHA 必須==HEAD / protected branch env 不可繞）全部補上。harness 測試 6→13 個，全 repo 105 passed（原 98 + 新 7）。
+
+**不在本輪**：pre-commit-gate（codex#4/#5，既有 sw-factory hook 問題）已另開 sw-factory#106，本 PR 不動。
+
 ## 五、未完成 / 待人接手
 
 1. ④ 探索測試 + AC 逐條對照：須換乾淨 session 派 qa-automation-architect（建者不自驗）。本 report 只完成機械半。

--- a/.claude/harness/report.md
+++ b/.claude/harness/report.md
@@ -67,6 +67,18 @@ runner 自測（子行程餵狀態檔），exit code 契約全符：
 
 **不在本輪**：pre-commit-gate（codex#4/#5，既有 sw-factory hook 問題）已另開 sw-factory#106，本 PR 不動。
 
+## 四點六、codex 第 2 輪複審退回修（2026-06-24）
+
+第 1 輪 7 問 → 第 2 輪剩 3 點（codex 確認上輪 #1/#2/#5 真修好）。本輪修以下 3 點，皆有回歸測試釘住：
+
+| # | 漏洞（為何上輪是假綠） | 修法 | 怎麼證明真修好 |
+|---|------|------|---------|
+| #3（核心）| 上輪 `PROTECTED_RE`/`ALLOWED_FEATURE_RE` 用 `:=` 預設賦值，仍可被普通 env **完全覆寫**。`PROTECTED_RE='^$' ALLOWED_FEATURE_RE='.*'` 即同時清空硬擋 + 放寬白名單 → main 兩層全繞。上輪測試只測「放寬白名單但 PROTECTED_RE 仍命中」，沒測「兩層同時放寬」＝刻意避開根因。 | 受保護判定錨在程式**內建常數** `readonly PROTECTED_BUILTIN_RE`（env 完全動不了）；env 只開 `PROTECTED_EXTRA_RE` 一個**收緊**方向（追加更多受保護分支，無清空/放寬路徑）。白名單放寬越不過第一層內建保護。 | `test_protected_block_not_bypassable_by_env_clearing_and_widening`：對 main+master 同時下 `PROTECTED_RE='^$' ALLOWED_FEATURE_RE='.*' PROTECTED_EXTRA_RE='^$'`，**仍須 exit 2 拒絕**——這條正是上輪假綠根因，現在釘死。另 `test_protected_extra_re_can_only_tighten` 驗 env 只能加擋（staging/x 被 EXTRA 列保護→拒絕）。 |
+| #4 | `independent-verify.sh` 把「全 skipping/neutral」（什麼都沒真跑）也判 PASS。 | 改：必須**至少一個 check 真 pass** 且無 fail/pending 才 success；全 skip/neutral/空 → UNKNOWN(2)，不可放行。順手修 line 74 `case` 嵌在 `$(...)` 內的 bash syntax error（拆成獨立 `case` 算 `CI_LABEL`，原 bug 會讓判定漏接而誤 exit 0）。 | 新增 `tests/test_independent_verify.py` 10 案：`test_all_skipping_is_not_pass`、`test_all_neutral_is_not_pass`、`test_no_check_is_not_pass` 全須 exit 2；`test_real_pass_passes`（真 pass→0）、`test_pass_plus_skipping_still_passes`（真 pass+skip→0）守住不過度收緊。 |
+| 流程不一致 | `ci.yml` 只在 `PR→main`/`push→main` 觸發，但流程是「loop 綠才開 PR」→ feature branch 還沒 PR 時無 CI 信號 → runner `wait_remote_ci` 找不到本輪 SHA 的 run → STOP(3) 卡死。 | `push` 觸發放寬到所有分支（`branches: ["**"]`）：feature branch 一 push 就跑 CI，runner 等的客觀 CI 信號實際會產生；`PR→main` 仍各自跑（含 fork PR）。 | push 後 GitHub Actions 對 feature commit 觸發 CI（PR #20 push 即驗）；runner `wait_remote_ci` 綁本輪 HEAD SHA 能撈到對應 run。 |
+
+**本輪驗證結果**：harness 兩檔測試 `test_harness_loop.py`(14) + `test_independent_verify.py`(10) 全綠；全 repo `116 passed, 5 xfailed`。本機綠，已 push 同 branch 觸發遠端 CI。
+
 ## 五、未完成 / 待人接手
 
 1. ④ 探索測試 + AC 逐條對照：須換乾淨 session 派 qa-automation-architect（建者不自驗）。本 report 只完成機械半。

--- a/.claude/harness/report.md
+++ b/.claude/harness/report.md
@@ -1,0 +1,53 @@
+# harness P1 試點 report — gov-bid-watch 首輪閉環
+
+> 任務：jooca-tw/hyweb-sw-factory#105｜spec：#94 `ship-pr-until-green-harness`
+> 日期：2026-06-24｜分支：`feat/harness-p1-ship-pr-green`｜PR：Hyweb-JayKao/gov-bid-watch#20
+
+## 一、閉環結果（寫 code → CI 綠 → 獨立驗）
+
+| 階段 | 結果 | 客觀信號（錨） |
+|------|------|---------------|
+| 寫 code（真實小任務：`tests/test_harness_loop.py`）| ✅ | 6 新測試，全套 92→98 passed |
+| ① loop 達標停 | ✅ | 本機 pytest 綠 + 遠端 CI `pytest` = pass（run 28089663924，watch exit 0）|
+| ④ 獨立驗收（機械半）| ✅ | 本機重跑全綠 + `gh pr checks 20` = pass |
+| ④ 獨立驗收（探索/AC 對照）| ⏳ 待獨立 session | 鐵則：建者不自驗，換 qa-automation-architect 乾淨 session |
+
+## 二、保險絲與守門驗收（spec §2.2/§2.3）
+
+runner 自測（子行程餵狀態檔），exit code 契約全符：
+
+| 情境 | 預期 | 實測 |
+|------|------|------|
+| 超過 MAX_ITER（=2，iter=3）| STOP exit 3 | ✅ exit 3「保險絲/迭代」|
+| 連續 3 輪同分（1,1,1）本機紅 | STOP exit 3 | ✅ exit 3「無進展」|
+| 分數在降（2,2,→1）| 不誤停，走 FAIL | ✅ exit 1 |
+| 首輪本機紅 | FAIL exit 1 | ✅ exit 1 |
+| 在受保護分支跑 | 拒絕 exit 2 | ✅ exit 2「受保護分支」|
+| pre-commit-gate 閘1（無 message）| block | ✅ block |
+| pre-commit-gate 閘3（測試紅）| block | ✅ block |
+
+回歸測試固化於 `tests/test_harness_loop.py`（進 CI，未來改 runner 會被擋）。
+
+## 三、不可逆邊界（鐵則，全程遵守）
+
+- 全程在隔離 worktree + feature 分支，未碰 main，避開每日 08:00 data-commit 窗。
+- 只 append commit（5 個），無 amend/rebase/force-push。
+- push 僅到 feature 分支。未 merge（做到開 PR 為止，merge 留 Jay）。
+
+## 四、baseline 數字（回填 spec §8 TOKEN_BUDGET）
+
+| 指標 | 本輪實測 | 備註 |
+|------|---------|------|
+| 迭代輪數（達標前）| 1 輪達標 | 真實小任務一次寫對；非典型多輪場景，僅作下限參考 |
+| wall-time（本機 runner 單輪）| < 5s（不含等遠端 CI）| 等遠端 CI 另 ~31s |
+| 遠端 CI job 時長 | 31s | ubuntu-latest + pip install + pytest |
+| token（本任務 agent 端，估計）| 中量；非 loop 內單輪量 | 本任務含建 harness 本身，非「loop 跑既有專案」代表性樣本 |
+
+> TOKEN_BUDGET 結論：本輪是「建 harness + 1 輪達標」混合樣本，不足以定 TOKEN_BUDGET 預設。
+> 建議之後拿 harness 跑 2–3 個「真正多輪修綠」任務，收每輪 token 再定預設。
+
+## 五、未完成 / 待人接手
+
+1. ④ 探索測試 + AC 逐條對照：須換乾淨 session 派 qa-automation-architect（建者不自驗）。本 report 只完成機械半。
+2. merge：留 Jay。merge 前主 session 跑 /codex:adversarial-review 跨模型審 PR #20 diff。
+3. ci.yml 已加且 PR #20 實證能跑綠；若要設 main branch protection required check，屬 repo 設定＝人類動作。

--- a/.claude/harness/ship-pr-loop.sh
+++ b/.claude/harness/ship-pr-loop.sh
@@ -22,14 +22,24 @@
 #
 # 狀態檔（跨輪累積，落 .claude/harness/.state/）：iter / 紅項分數歷史 / 起始時間 / token（由 agent 回填）。
 
-set -uo pipefail
+set -euo pipefail
 
 # ---------- 設定（可由環境變數覆寫，預設＝spec §8 拍板值）----------
-: "${MAX_ITER:=8}"            # 保險絲：迭代輪數硬上限
+: "${MAX_ITER:=8}"            # 保險絲：迭代輪數硬上限（語意：最多跑 MAX_ITER 輪，第 MAX_ITER 輪後停）
 : "${NO_PROGRESS_N:=3}"       # 無進展停：連續 N 輪紅項分數沒降
 : "${MAX_WALL:=3600}"         # 保險絲：牆鐘秒數上限（60 分）
 : "${TEST_CMD:=python3 -m pytest -q}"  # 客觀本機信號（對齊 VERIFY.md；本機用 python3，CI 用 python）
-: "${BRANCH_PREFIX_MAIN:=main}"        # 受保護分支名（禁直接 push）
+
+# 受保護分支守門＝白名單制（codex#3）：只有「feature 分支」可被 loop 動作（push）。
+# feature 分支＝符合 ALLOWED_FEATURE_RE 的分支名（預設 feat/ fix/ chore/ docs/ test/ refactor/ 開頭）。
+# 任何其他分支（main/master/release*/prod*/develop…）一律拒絕。
+# 安全鐵則：此白名單【不可】由普通 env 放寬到涵蓋受保護分支——下方 guard 會把
+# 「未命中白名單」一律當受保護，不存在「把 main 加進白名單」這條路。
+: "${ALLOWED_FEATURE_RE:=^(feat|fix|chore|docs|test|refactor|perf|ci|build|style)/.+}"
+# 永遠拒絕清單（即使有人亂改 ALLOWED_FEATURE_RE 想放行，這層仍硬擋）。
+# 可 env 覆寫以涵蓋更多受保護分支或供測試；注意覆寫只能【放寬擋誰】，
+# 放寬本清單不會放行非 feature 分支——白名單第二層仍獨立把關。
+: "${PROTECTED_RE:=^(main|master|develop|release([/-].*)?|prod([/-].*)?|production([/-].*)?|hotfix([/-].*)?)$}"
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 STATE_DIR="$ROOT/.claude/harness/.state"
@@ -77,37 +87,83 @@ json.dump(d, open(path,"w"), ensure_ascii=False, indent=2)
 PY
 }
 
-# ---------- 不可逆邊界守門（任何時候被叫到都先擋）----------
+# ---------- 不可逆邊界守門（白名單制，任何時候被叫到都先擋）----------
+# codex#3：黑名單可被 env 繞過。改白名單——只有命中 ALLOWED_FEATURE_RE 的 feature
+# 分支放行；同時 PROTECTED_RE 永遠硬擋（即使有人放寬白名單也擋得住）。
 guard_irreversible() {
   local b; b="$(cur_branch)"
-  [ "$b" = "$BRANCH_PREFIX_MAIN" ] && die "在受保護分支 '${b}' 上，禁止 loop 動作。請在隔離 worktree 的 feature 分支跑。"
-  # worktree dirty 檢查交給 agent 的小步 commit，這裡只擋分支
+  [ -n "$b" ] || die "無法取得當前分支名，拒絕 loop 動作。"
+  # 第一層：永遠拒絕清單（防有人改白名單想放行受保護分支）
+  if printf '%s' "$b" | grep -Eq "$PROTECTED_RE"; then
+    die "在受保護分支 '${b}' 上，禁止 loop 動作（PROTECTED_RE 硬擋）。請在隔離 worktree 的 feature 分支跑。"
+  fi
+  # 第二層：白名單——非 feature 分支一律拒絕
+  if ! printf '%s' "$b" | grep -Eq "$ALLOWED_FEATURE_RE"; then
+    die "分支 '${b}' 非 feature 分支（未命中白名單 ${ALLOWED_FEATURE_RE}），禁止 loop 動作。"
+  fi
   return 0
+}
+
+# 驗 TEST_CMD 白名單（在主流程前置呼叫，非 command substitution 內，避免 die 被 subshell 吞）。
+# 不用 eval（防注入）：只允許 python / python3 / pytest 開頭。其他拒絕 → die(exit 2)。
+assert_test_cmd_safe() {
+  local first
+  read -ra _TEST_ARGV <<<"$TEST_CMD"
+  first="${_TEST_ARGV[0]:-}"
+  case "$first" in
+    python|python3|pytest) return 0 ;;
+    *) die "TEST_CMD 首字 '${first}' 不在白名單(python/python3/pytest)，拒絕執行。" ;;
+  esac
+}
+
+# 執行 TEST_CMD（陣列分詞，不經 eval）。前提：已先跑 assert_test_cmd_safe。
+run_test_cmd() {
+  read -ra _TEST_ARGV <<<"$TEST_CMD"
+  ( cd "$ROOT" && "${_TEST_ARGV[@]}" )
 }
 
 # 客觀分數：未通過的測試「信號」數。pytest 失敗→取 failed 數；全綠→0。
 # 回 0 = 達標候選；>0 = 還有紅項。
 run_local_signal() {
-  local log="$STATE_DIR/last-test.log"
-  if ( cd "$ROOT" && eval "$TEST_CMD" ) >"$log" 2>&1; then
+  local log="$STATE_DIR/last-test.log" n
+  if run_test_cmd >"$log" 2>&1; then
     echo 0; return 0
   fi
   # 從 pytest 尾巴抓 "N failed"；抓不到就記 1（有紅但數不清）
-  local n
-  n="$(grep -oE '[0-9]+ failed' "$log" | grep -oE '[0-9]+' | tail -1)"
+  n="$(grep -oE '[0-9]+ failed' "$log" | grep -oE '[0-9]+' | tail -1 || true)"
   echo "${n:-1}"
 }
 
-# 等遠端 CI：對當前 branch 的最新 commit 等 GitHub Actions 結論。
-# 回 0=success / 1=failure / 2=未知(無 CI run / gh 不可用)
+# 等遠端 CI：對【本輪 push 的 commit SHA】等 GitHub Actions 結論。
+# codex#2：原本抓 branch 最新 run，可能是上一輪舊 commit 的 run → 拿舊綠當本輪成功。
+#   改為：只認 headSha == 本輪 HEAD 的 run；找不到對應本輪 SHA 的 run 視為「未知」。
+# 參數：$1 = 期望的 commit SHA（本輪 push 的 HEAD）。
+# 回 0=success / 1=failure / 2=未知(gh 不可用 / 無對應本輪 SHA 的 run / 逾時)
 wait_remote_ci() {
-  local b; b="$(cur_branch)"
-  command -v gh >/dev/null 2>&1 || { say "⚠️ 無 gh CLI，跳過遠端 CI 等待（只憑本機信號）"; return 2; }
-  say "⏳ 等遠端 CI（branch=${b}）…"
-  # gh run watch 對最新一次該 branch 的 run；先抓 run id
-  local rid
-  rid="$(gh run list --branch "$b" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)"
-  [ -n "$rid" ] || { say "⚠️ 該 branch 尚無 CI run（可能 CI 未啟用或 push 未觸發）"; return 2; }
+  local b expect rid head_sha tries
+  b="$(cur_branch)"
+  expect="${1:-}"
+  command -v gh >/dev/null 2>&1 || { say "⚠️ 無 gh CLI，無法取得遠端 CI 達標信號"; return 2; }
+  [ -n "$expect" ] || { say "⚠️ 未提供本輪 commit SHA，無法綁定 CI run"; return 2; }
+  say "⏳ 等遠端 CI（branch=${b}，commit=${expect:0:8}）…"
+  # 輪詢等「該 branch 上 headSha==本輪 SHA」的 run 出現。
+  # 次數/間隔可 env 覆寫（CI_POLL_TRIES/CI_POLL_SLEEP，預設 ~10 分鐘；測試可調快）。
+  : "${CI_POLL_TRIES:=60}"
+  : "${CI_POLL_SLEEP:=10}"
+  tries=0
+  rid=""
+  while [ "$tries" -lt "$CI_POLL_TRIES" ]; do
+    rid="$(gh run list --branch "$b" --limit 20 \
+            --json databaseId,headSha \
+            -q ".[] | select(.headSha==\"$expect\") | .databaseId" 2>/dev/null | head -1 || true)"
+    [ -n "$rid" ] && break
+    tries=$(( tries + 1 ))
+    sleep "$CI_POLL_SLEEP"
+  done
+  [ -n "$rid" ] || { say "⚠️ 逾時：找不到 commit ${expect:0:8} 對應的 CI run（CI 未觸發或未啟用）"; return 2; }
+  # 二次確認該 run 的 headSha 確實==本輪 SHA（防競態抓錯）
+  head_sha="$(gh run view "$rid" --json headSha -q '.headSha' 2>/dev/null)"
+  [ "$head_sha" = "$expect" ] || { say "⚠️ run ${rid} 的 headSha(${head_sha:0:8}) 不等於本輪(${expect:0:8})，拒認"; return 2; }
   gh run watch "$rid" --exit-status >/dev/null 2>&1 && return 0 || return 1
 }
 
@@ -127,21 +183,25 @@ fi
 
 # ---------- 主：跑一輪 ----------
 guard_irreversible
+assert_test_cmd_safe   # TEST_CMD 白名單前置驗（die 在主流程才不被 subshell 吞）
 
 # init 狀態（首輪）
 [ -f "$STATE" ] || write_state iter=0 start_ts="$(now)" started="$(nowiso)"
 iter="$(read_state iter)"; iter="${iter:-0}"
 start="$(read_state start_ts)"; start="${start:-$(now)}"
 
+# ── 保險絲 A：迭代上限（codex#7 off-by-one 修正）──
+# 語意：最多跑 MAX_ITER 輪。iter 記的是「已完成的輪數」。
+#   若已完成 MAX_ITER 輪（iter >= MAX_ITER），本次不再起新一輪 → STOP。
+#   檢查放在自增【前】，故 MAX_ITER=8 時最後實際執行的是第 8 輪，第 9 次呼叫即停。
+if [ "$iter" -ge "$MAX_ITER" ]; then
+  say "🛑 STOP[保險絲/迭代]：已完成 ${iter} 輪，達 MAX_ITER=${MAX_ITER} 上限。停 + 回報人（貼最後紅項 + 最近 diff）。"
+  exit 3
+fi
+
 iter=$(( iter + 1 ))
 write_state iter="$iter" last_run="$(nowiso)"
 say "═══ Ship-PR loop 第 ${iter}/${MAX_ITER} 輪 ═══"
-
-# ── 保險絲 A：迭代上限 ──
-if [ "$iter" -gt "$MAX_ITER" ]; then
-  say "🛑 STOP[保險絲/迭代]：iter=${iter} 超過 MAX_ITER=${MAX_ITER}。停 + 回報人（貼最後紅項 + 最近 diff）。"
-  exit 3
-fi
 
 # ── 保險絲 B：牆鐘上限 ──
 elapsed=$(( $(now) - start ))
@@ -190,21 +250,31 @@ fi
 guard_irreversible
 say "✅ 本機測試全綠。push 到 feature 分支觸發遠端 CI（禁 force / 禁 main）…"
 b="$(cur_branch)"
-# 明確用普通 push（無 --force）；push 到 origin/<feature 同名>
-if ! git -C "$ROOT" push -u origin "$b" 2>&1 | tee /dev/stderr | grep -qiv "fatal"; then
-  : # push 結果由下方 CI 等待與 exit code 決定，這裡不武斷判失敗
+# codex#2：push 失敗即 FAIL，不可吞 exit code。明確用普通 push（無 --force）。
+if ! git -C "$ROOT" push -u origin "$b"; then
+  say "🔴 FAIL：push origin/${b} 失敗（網路 / 權限 / non-fast-forward）。"
+  say "   未推上＝沒有可被 CI 驗的遠端 commit。修好 push 問題再跑本 runner（禁用 --force 繞過）。"
+  exit 1
 fi
+# 取本輪實際 push 上去的 HEAD SHA，綁定後面要等的 CI run（codex#2）
+HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
+[ -n "$HEAD_SHA" ] || { say "🔴 FAIL：無法取得本輪 HEAD SHA。"; exit 1; }
 
-# ── 等遠端 CI ──
-wait_remote_ci; ci=$?
+# ── 等遠端 CI（綁定本輪 HEAD SHA）──
+# set -e 安全：用 `|| ci=$?` 取回傳碼，否則 wait_remote_ci 回非 0 會直接終止腳本。
+ci=0
+wait_remote_ci "$HEAD_SHA" || ci=$?
 case "$ci" in
-  0) say "🟢 PASS：本機綠 + 遠端 CI success。達標停 → 進 ④獨立驗收（換 session 跑 .claude/harness/independent-verify.sh）。"
-     write_state outcome="pass-pending-verify" passed_ts="$(nowiso)"
+  0) say "🟢 PASS：本機綠 + 遠端 CI success（commit ${HEAD_SHA:0:8}）。達標停 → 進 ④獨立驗收（換 session 跑 .claude/harness/independent-verify.sh）。"
+     write_state outcome="pass-verified" passed_ts="$(nowiso)" passed_sha="$HEAD_SHA"
      exit 0 ;;
   1) say "🔴 FAIL：本機綠但遠端 CI 紅（環境/整合差異）。把 CI 紅項當 failing 信號回去改。"
+     write_state outcome="fail-ci-red"
      exit 1 ;;
-  2) say "🟡 PASS(本機)：遠端 CI 不可用/未觸發，僅本機綠。"
-     say "   ⚠️ 缺遠端 CI 達標信號＝退化成本機自評（違反 §5 前提1）。請確認 ci.yml 已啟用且 PR 已開，再續。"
-     write_state outcome="pass-local-only" passed_ts="$(nowiso)"
-     exit 0 ;;
+  2) # codex#1：CI 不可用 / 未觸發 / 找不到本輪 SHA 的 run ≠ 達標。【不可】exit 0 放行為綠。
+     say "🛑 STOP[缺客觀 CI 信號]：遠端 CI 不可用 / 未觸發 / 找不到 commit ${HEAD_SHA:0:8} 對應的 run。"
+     say "   依 spec §2.2 達標鐵則：必須【本機綠 + 遠端 CI conclusion=success】。"
+     say "   缺遠端 CI＝無法達標，禁止當綠放行。請確認 ci.yml 已啟用且該 commit 觸發了 CI，再跑本 runner。"
+     write_state outcome="stop-no-ci"
+     exit 3 ;;
 esac

--- a/.claude/harness/ship-pr-loop.sh
+++ b/.claude/harness/ship-pr-loop.sh
@@ -30,16 +30,28 @@ set -euo pipefail
 : "${MAX_WALL:=3600}"         # 保險絲：牆鐘秒數上限（60 分）
 : "${TEST_CMD:=python3 -m pytest -q}"  # 客觀本機信號（對齊 VERIFY.md；本機用 python3，CI 用 python）
 
-# 受保護分支守門＝白名單制（codex#3）：只有「feature 分支」可被 loop 動作（push）。
-# feature 分支＝符合 ALLOWED_FEATURE_RE 的分支名（預設 feat/ fix/ chore/ docs/ test/ refactor/ 開頭）。
-# 任何其他分支（main/master/release*/prod*/develop…）一律拒絕。
-# 安全鐵則：此白名單【不可】由普通 env 放寬到涵蓋受保護分支——下方 guard 會把
-# 「未命中白名單」一律當受保護，不存在「把 main 加進白名單」這條路。
+# ──────────────────────────────────────────────────────────────────────────
+# 受保護分支守門（codex#3 第 2 輪：env 不可放寬/清空，只能收緊）
+# ──────────────────────────────────────────────────────────────────────────
+# spec §2.3 不可逆邊界硬要求：受保護分支守門「env 無法關掉」。
+#
+# 上一輪用 `: "${PROTECTED_RE:=...}"` / `: "${ALLOWED_FEATURE_RE:=...}"` 仍可被
+# 普通 env 完全覆寫：`PROTECTED_RE='^$' ALLOWED_FEATURE_RE='.*'` 就同時清空硬擋 +
+# 放寬白名單，讓 main 兩層都繞過（= 假修）。
+#
+# 第 2 輪改法：
+#   (1) 受保護判定錨在【程式內建常數】PROTECTED_BUILTIN_RE，完全不吃 env，env 動不了它。
+#   (2) env 只開「收緊」一個方向：PROTECTED_EXTRA_RE 可【追加】更多受保護分支，
+#       不存在「移除/清空內建保護」的 env 路徑。
+#   (3) feature 白名單同理：實際放行條件＝命中白名單 AND 不命中內建保護；
+#       ALLOWED_FEATURE_RE 可由 env 收窄；即使被放成 '.*'，內建保護仍先硬擋，
+#       不存在「把 main 加進白名單」這條路。
+# 內建受保護分支常數——【不可由 env 覆寫或清空】。
+readonly PROTECTED_BUILTIN_RE='^(main|master|develop|release([/-].*)?|prod([/-].*)?|production([/-].*)?|hotfix([/-].*)?)$'
+# env 只能【追加】更多受保護分支（收緊），預設不追加。設了也只會「多擋」，不會少擋。
+: "${PROTECTED_EXTRA_RE:=}"
+# feature 白名單：env 可收窄（少放行），放寬無效——下方 guard 內建保護永遠先擋。
 : "${ALLOWED_FEATURE_RE:=^(feat|fix|chore|docs|test|refactor|perf|ci|build|style)/.+}"
-# 永遠拒絕清單（即使有人亂改 ALLOWED_FEATURE_RE 想放行，這層仍硬擋）。
-# 可 env 覆寫以涵蓋更多受保護分支或供測試；注意覆寫只能【放寬擋誰】，
-# 放寬本清單不會放行非 feature 分支——白名單第二層仍獨立把關。
-: "${PROTECTED_RE:=^(main|master|develop|release([/-].*)?|prod([/-].*)?|production([/-].*)?|hotfix([/-].*)?)$}"
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 STATE_DIR="$ROOT/.claude/harness/.state"
@@ -87,17 +99,24 @@ json.dump(d, open(path,"w"), ensure_ascii=False, indent=2)
 PY
 }
 
-# ---------- 不可逆邊界守門（白名單制，任何時候被叫到都先擋）----------
-# codex#3：黑名單可被 env 繞過。改白名單——只有命中 ALLOWED_FEATURE_RE 的 feature
-# 分支放行；同時 PROTECTED_RE 永遠硬擋（即使有人放寬白名單也擋得住）。
+# ---------- 不可逆邊界守門（任何時候被叫到都先擋）----------
+# codex#3（第 2 輪）：受保護判定錨在內建常數 PROTECTED_BUILTIN_RE，env 動不了它；
+# env 只能用 PROTECTED_EXTRA_RE 追加更多保護（收緊）。三層：
+#   第一層：內建受保護清單硬擋（env 無法清空/放寬）。
+#   第一層+：env 追加的額外受保護分支（只多擋不少擋）。
+#   第二層：feature 白名單——非 feature 分支一律拒絕（env 放寬白名單也越不過第一層）。
 guard_irreversible() {
   local b; b="$(cur_branch)"
   [ -n "$b" ] || die "無法取得當前分支名，拒絕 loop 動作。"
-  # 第一層：永遠拒絕清單（防有人改白名單想放行受保護分支）
-  if printf '%s' "$b" | grep -Eq "$PROTECTED_RE"; then
-    die "在受保護分支 '${b}' 上，禁止 loop 動作（PROTECTED_RE 硬擋）。請在隔離 worktree 的 feature 分支跑。"
+  # 第一層：內建受保護清單（程式常數，env 無法覆寫/清空）。
+  if printf '%s' "$b" | grep -Eq "$PROTECTED_BUILTIN_RE"; then
+    die "在受保護分支 '${b}' 上，禁止 loop 動作（內建保護硬擋，env 無法繞過）。請在隔離 worktree 的 feature 分支跑。"
   fi
-  # 第二層：白名單——非 feature 分支一律拒絕
+  # 第一層+：env 追加的額外受保護分支（只能收緊；空字串＝不追加）。
+  if [ -n "$PROTECTED_EXTRA_RE" ] && printf '%s' "$b" | grep -Eq "$PROTECTED_EXTRA_RE"; then
+    die "在受保護分支 '${b}' 上，禁止 loop 動作（PROTECTED_EXTRA_RE 追加保護）。"
+  fi
+  # 第二層：白名單——非 feature 分支一律拒絕（放寬白名單越不過第一層內建保護）。
   if ! printf '%s' "$b" | grep -Eq "$ALLOWED_FEATURE_RE"; then
     die "分支 '${b}' 非 feature 分支（未命中白名單 ${ALLOWED_FEATURE_RE}），禁止 loop 動作。"
   fi

--- a/.claude/harness/ship-pr-loop.sh
+++ b/.claude/harness/ship-pr-loop.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# ship-pr-loop.sh — ① Ship-PR-Until-Green loop runner（harness P1）
+#
+# spec: docs/specs/ship-pr-until-green-harness.md（sw-factory）§2
+# 定位：編排「跑客觀信號 → push → 等 CI → 紅就回報 failing 信號 → 達標才交獨立驗收」
+#       這條無聊的來回，把三層終止 / 保險絲 / 不可逆邊界守住。
+#
+# 它【不】替你寫業務 code——寫 code 是 agent（黃仁勳）戴 CTO 帽做的事。
+# 每一輪的順序是：agent 改一小步 code → 呼叫本 runner 跑一輪 → runner 回報
+#   PASS（達標，進獨立驗收） / FAIL（紅，附 failing 信號，回去再改） / STOP（保險絲/無進展，停 + 回報人）。
+#
+# 錨點鐵則（spec §2.2）：達標一律錨在「本機 pytest 綠 + 遠端 CI conclusion=success」，
+#   禁用「agent 自稱做完」當終止條件。
+#
+# 不可逆邊界鐵則（spec §2.3）：本 runner 只做可逆動作（append commit / push 到 feature 分支 / 開 PR）。
+#   amend / rebase / force-push / push 到 main / merge 一律【拒絕執行】並 exit 2。merge 永遠人按。
+#
+# 用法：
+#   在隔離 worktree 的 feature 分支上，agent 改完一小步後跑：
+#     bash .claude/harness/ship-pr-loop.sh            # 跑一輪（推薦：agent 控迴圈，每輪自己改 code）
+#     bash .claude/harness/ship-pr-loop.sh --status   # 只印目前狀態 / 保險絲剩餘額度，不動作
+#
+# 狀態檔（跨輪累積，落 .claude/harness/.state/）：iter / 紅項分數歷史 / 起始時間 / token（由 agent 回填）。
+
+set -uo pipefail
+
+# ---------- 設定（可由環境變數覆寫，預設＝spec §8 拍板值）----------
+: "${MAX_ITER:=8}"            # 保險絲：迭代輪數硬上限
+: "${NO_PROGRESS_N:=3}"       # 無進展停：連續 N 輪紅項分數沒降
+: "${MAX_WALL:=3600}"         # 保險絲：牆鐘秒數上限（60 分）
+: "${TEST_CMD:=python3 -m pytest -q}"  # 客觀本機信號（對齊 VERIFY.md；本機用 python3，CI 用 python）
+: "${BRANCH_PREFIX_MAIN:=main}"        # 受保護分支名（禁直接 push）
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+STATE_DIR="$ROOT/.claude/harness/.state"
+STATE="$STATE_DIR/loop.json"
+SCORE_LOG="$STATE_DIR/scores.log"     # 每輪紅項分數，一行一輪
+mkdir -p "$STATE_DIR"
+
+# ---------- 工具 ----------
+now()  { date -u +%s; }
+nowiso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+say()  { printf '%s\n' "$*" >&2; }
+die()  { say "🔴 $*"; exit 2; }
+
+cur_branch() { git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null; }
+
+# read_state KEY -> value（空→預設）
+read_state() {
+  python3 - "$STATE" "$1" <<'PY' 2>/dev/null || true
+import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception:
+    d={}
+print(d.get(sys.argv[2], ""))
+PY
+}
+
+write_state() {
+  python3 - "$STATE" "$@" <<'PY' 2>/dev/null
+import json,sys
+path=sys.argv[1]
+try:
+    d=json.load(open(path))
+except Exception:
+    d={}
+for kv in sys.argv[2:]:
+    k,_,v=kv.partition("=")
+    # 數字盡量存數字
+    try: v=int(v)
+    except ValueError:
+        try: v=float(v)
+        except ValueError: pass
+    d[k]=v
+json.dump(d, open(path,"w"), ensure_ascii=False, indent=2)
+PY
+}
+
+# ---------- 不可逆邊界守門（任何時候被叫到都先擋）----------
+guard_irreversible() {
+  local b; b="$(cur_branch)"
+  [ "$b" = "$BRANCH_PREFIX_MAIN" ] && die "在受保護分支 '${b}' 上，禁止 loop 動作。請在隔離 worktree 的 feature 分支跑。"
+  # worktree dirty 檢查交給 agent 的小步 commit，這裡只擋分支
+  return 0
+}
+
+# 客觀分數：未通過的測試「信號」數。pytest 失敗→取 failed 數；全綠→0。
+# 回 0 = 達標候選；>0 = 還有紅項。
+run_local_signal() {
+  local log="$STATE_DIR/last-test.log"
+  if ( cd "$ROOT" && eval "$TEST_CMD" ) >"$log" 2>&1; then
+    echo 0; return 0
+  fi
+  # 從 pytest 尾巴抓 "N failed"；抓不到就記 1（有紅但數不清）
+  local n
+  n="$(grep -oE '[0-9]+ failed' "$log" | grep -oE '[0-9]+' | tail -1)"
+  echo "${n:-1}"
+}
+
+# 等遠端 CI：對當前 branch 的最新 commit 等 GitHub Actions 結論。
+# 回 0=success / 1=failure / 2=未知(無 CI run / gh 不可用)
+wait_remote_ci() {
+  local b; b="$(cur_branch)"
+  command -v gh >/dev/null 2>&1 || { say "⚠️ 無 gh CLI，跳過遠端 CI 等待（只憑本機信號）"; return 2; }
+  say "⏳ 等遠端 CI（branch=${b}）…"
+  # gh run watch 對最新一次該 branch 的 run；先抓 run id
+  local rid
+  rid="$(gh run list --branch "$b" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null)"
+  [ -n "$rid" ] || { say "⚠️ 該 branch 尚無 CI run（可能 CI 未啟用或 push 未觸發）"; return 2; }
+  gh run watch "$rid" --exit-status >/dev/null 2>&1 && return 0 || return 1
+}
+
+# ---------- --status ----------
+if [ "${1:-}" = "--status" ]; then
+  iter="$(read_state iter)"; iter="${iter:-0}"
+  start="$(read_state start_ts)"; start="${start:-$(now)}"
+  elapsed=$(( $(now) - start ))
+  say "── ship-pr-loop 狀態 ──"
+  say "branch       : $(cur_branch)"
+  say "iter         : ${iter} / ${MAX_ITER}（剩 $(( MAX_ITER - iter )) 輪）"
+  say "wall elapsed : ${elapsed}s / ${MAX_WALL}s"
+  say "no-progress  : 連續沒降額度 ${NO_PROGRESS_N}"
+  say "scores       : $(tr '\n' ' ' < "$SCORE_LOG" 2>/dev/null)"
+  exit 0
+fi
+
+# ---------- 主：跑一輪 ----------
+guard_irreversible
+
+# init 狀態（首輪）
+[ -f "$STATE" ] || write_state iter=0 start_ts="$(now)" started="$(nowiso)"
+iter="$(read_state iter)"; iter="${iter:-0}"
+start="$(read_state start_ts)"; start="${start:-$(now)}"
+
+iter=$(( iter + 1 ))
+write_state iter="$iter" last_run="$(nowiso)"
+say "═══ Ship-PR loop 第 ${iter}/${MAX_ITER} 輪 ═══"
+
+# ── 保險絲 A：迭代上限 ──
+if [ "$iter" -gt "$MAX_ITER" ]; then
+  say "🛑 STOP[保險絲/迭代]：iter=${iter} 超過 MAX_ITER=${MAX_ITER}。停 + 回報人（貼最後紅項 + 最近 diff）。"
+  exit 3
+fi
+
+# ── 保險絲 B：牆鐘上限 ──
+elapsed=$(( $(now) - start ))
+if [ "$elapsed" -gt "$MAX_WALL" ]; then
+  say "🛑 STOP[保險絲/牆鐘]：已跑 ${elapsed}s 超過 MAX_WALL=${MAX_WALL}s。停 + 回報人。"
+  exit 3
+fi
+
+# ── 取客觀本機信號 ──
+say "▶ 跑本機測試信號：$TEST_CMD"
+score="$(run_local_signal)"
+echo "$score" >> "$SCORE_LOG"
+say "▶ 本輪紅項分數（未過測試數）：$score"
+
+# ── 無進展停：連續 NO_PROGRESS_N 輪分數沒降 ──
+# 不用 mapfile（bash 4+，macOS 預設 bash 3.2 無此內建）→ 用 portable 讀法。
+HIST=()
+while IFS= read -r _line; do HIST+=("$_line"); done < "$SCORE_LOG"
+nh=${#HIST[@]}
+if [ "$nh" -ge "$NO_PROGRESS_N" ] && [ "$score" -gt 0 ]; then
+  stuck=1
+  base="${HIST[$((nh-1))]}"
+  i=2
+  while [ "$i" -le "$NO_PROGRESS_N" ]; do
+    prev="${HIST[$((nh-i))]}"
+    # 分數有降（prev > base）就不算卡死
+    if [ "${prev:-0}" -gt "${base:-0}" ]; then stuck=0; break; fi
+    i=$(( i + 1 ))
+  done
+  if [ "$stuck" -eq 1 ]; then
+    recent="$(tail -n "$NO_PROGRESS_N" "$SCORE_LOG" | tr '\n' ' ')"
+    say "🛑 STOP[無進展]：連續 ${NO_PROGRESS_N} 輪紅項分數沒降（最近：${recent}）。判定卡死，停 + 回報人。"
+    exit 3
+  fi
+fi
+
+# ── 本機紅 → 回去再改（不 push 髒 commit）──
+if [ "$score" -gt 0 ]; then
+  say "🔴 FAIL：本機測試有 $score 項紅。把它當下一個 failing 信號，回去改一小步再跑本 runner。"
+  say "   失敗末尾："
+  tail -n 12 "$STATE_DIR/last-test.log" >&2
+  exit 1
+fi
+
+# ── 本機綠 → push 觸發遠端 CI（push 前再次擋受保護分支）──
+guard_irreversible
+say "✅ 本機測試全綠。push 到 feature 分支觸發遠端 CI（禁 force / 禁 main）…"
+b="$(cur_branch)"
+# 明確用普通 push（無 --force）；push 到 origin/<feature 同名>
+if ! git -C "$ROOT" push -u origin "$b" 2>&1 | tee /dev/stderr | grep -qiv "fatal"; then
+  : # push 結果由下方 CI 等待與 exit code 決定，這裡不武斷判失敗
+fi
+
+# ── 等遠端 CI ──
+wait_remote_ci; ci=$?
+case "$ci" in
+  0) say "🟢 PASS：本機綠 + 遠端 CI success。達標停 → 進 ④獨立驗收（換 session 跑 .claude/harness/independent-verify.sh）。"
+     write_state outcome="pass-pending-verify" passed_ts="$(nowiso)"
+     exit 0 ;;
+  1) say "🔴 FAIL：本機綠但遠端 CI 紅（環境/整合差異）。把 CI 紅項當 failing 信號回去改。"
+     exit 1 ;;
+  2) say "🟡 PASS(本機)：遠端 CI 不可用/未觸發，僅本機綠。"
+     say "   ⚠️ 缺遠端 CI 達標信號＝退化成本機自評（違反 §5 前提1）。請確認 ci.yml 已啟用且 PR 已開，再續。"
+     write_state outcome="pass-local-only" passed_ts="$(nowiso)"
+     exit 0 ;;
+esac

--- a/.claude/hooks/pre-commit-gate
+++ b/.claude/hooks/pre-commit-gate
@@ -1,0 +1,134 @@
+#!/bin/bash
+# pre-commit-gate — Claude Code PreToolUse:Bash hook
+#
+# 在 git commit 真正執行前把三道閘，任一不過就 block 並印出原因：
+#   1. 有 commit message（git commit 帶 -m / -F / -t，禁開編輯器空 commit）
+#   2. staged diff ≤ PRECOMMIT_MAX_DIFF 行（預設 150，可由環境變數覆寫）
+#   3. 測試綠燈（跑 PRECOMMIT_TEST_CMD；未設定 = skip-with-warning，不擋）
+#
+# 設計來源：Cerebras Sarah Chieng Tip 7（收緊 commit 權限建護欄）。
+# 取代 settings.json 裡被移除的 `Bash(git commit:*)` allow —— 改由本 hook 把關。
+#
+# 慣例（對齊 FLUX charter-tier0-guard.sh）：
+#   - 從 stdin 讀 tool-call JSON，只處理 git commit 的 Bash 呼叫
+#   - block：印 {"decision":"block","reason":...} 後 exit 0
+#   - 放行：印 {} 後 exit 0
+#   - hook 內部錯誤不應阻塞（不要 set -e）；非 git commit 一律放行
+#
+# 本機自測（不經 Claude Code）：
+#   echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}' | .claude/hooks/pre-commit-gate
+
+# 在 fork 出的任何路徑都能跑：優先用 Claude Code 注入的專案根
+: "${CLAUDE_PROJECT_DIR:=$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+: "${PRECOMMIT_MAX_DIFF:=150}"
+# 失敗軌跡落地目錄（建 SkillOpt corpus；issue #8）。可由環境變數覆寫。
+: "${PRECOMMIT_TRAJECTORY_DIR:=$CLAUDE_PROJECT_DIR/.claude/trajectories}"
+
+allow()  { echo "{}"; exit 0; }
+# 用 python 安全 JSON-encode reason（中文 / 換行 / 引號 / log 裡的壞 byte 都不破 JSON）
+block()  {
+  REASON="$1" python3 -c "import json,os; r=os.environb[b'REASON'].decode('utf-8','replace'); print(json.dumps({'decision':'block','reason':r}))"
+  exit 0
+}
+
+# capture_trajectory — 把一條「測試失敗軌跡」append 進 trajectories/ 的 JSONL（issue #8）。
+# 只在閘3（測試沒過）呼叫；閘1/閘2 是 commit 衛生不是訓練訊號，不捕。
+# 鐵則：
+#   - 必在 block() 之前呼叫（block 內含 exit）。
+#   - error-tolerant：本函式任何失敗都不得影響 commit 的 block/allow 判定
+#     （故全部包進 subshell + `|| true`，且只寫 stderr，不碰 stdout 的 JSON 決策）。
+#   - 序列化走 python3 json.dumps：diff 含任意 byte / 引號 / 換行都不破 JSON。
+# 參數：$1=測試指令  $2=完整 fail log 路徑
+capture_trajectory() {
+  (
+    TEST_CMD="$1"
+    LOG_PATH="$2"
+    mkdir -p "$PRECOMMIT_TRAJECTORY_DIR" 2>/dev/null || exit 0
+    OUT="$PRECOMMIT_TRAJECTORY_DIR/failures.jsonl"
+    # skill/prompt 版本指紋：repo 子樹的 HEAD commit（沒 git 就標 unknown）
+    SKILL_FP=$(cd "$CLAUDE_PROJECT_DIR" 2>/dev/null \
+      && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    # context proxy：hook 唯一拿得到的脈絡——branch + 本次想 commit 的命令全文
+    BRANCH=$(cd "$CLAUDE_PROJECT_DIR" 2>/dev/null \
+      && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    STAGED_DIFF=$(cd "$CLAUDE_PROJECT_DIR" 2>/dev/null && git diff --cached 2>/dev/null)
+    FAIL_LOG=$(cat "$LOG_PATH" 2>/dev/null)
+    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+    OUT="$OUT" TS="$TS" SCHEMA="1" GATE="test-green" BRANCH="$BRANCH" COMMIT_CMD="$CMD" \
+    TEST_CMD="$TEST_CMD" SKILL_FP="$SKILL_FP" \
+    STAGED_DIFF="$STAGED_DIFF" FAIL_LOG="$FAIL_LOG" \
+    python3 -c '
+import json, os
+g = lambda k: os.environb.get(k.encode(), b"").decode("utf-8", "replace")
+rec = {
+    "schema": int(g("SCHEMA") or "1"),
+    "ts": g("TS"),
+    "gate": g("GATE"),
+    "branch": g("BRANCH"),
+    "commit_cmd": g("COMMIT_CMD"),
+    "test_cmd": g("TEST_CMD"),
+    "skill_fingerprint": g("SKILL_FP"),
+    "staged_diff": g("STAGED_DIFF"),
+    "fail_log": g("FAIL_LOG"),
+    # future correlation 欄位（本期不填；修正成功的 diff 在 fail 當下拿不到）：
+    "fix_diff": None,
+    "outcome": "fail",
+}
+with open(os.environ["OUT"], "a", encoding="utf-8") as f:
+    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+' 2>/dev/null
+  ) || true
+}
+
+# --- 讀 tool-call JSON ---
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+[ "$TOOL_NAME" = "Bash" ] || allow
+
+CMD=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# 只攔「實際執行 git commit」的命令位置（避免 heredoc / git log --grep 'commit' 等誤判）
+FIRST_LINE=$(printf '%s' "$CMD" | head -n 1)
+echo "$FIRST_LINE" | grep -qE "(^|[;&|]| )git( -[A-Za-z=./_-]+ | )commit\b" || allow
+
+# === 閘 1：有 commit message ===
+# 視為「帶 message」的情形（任一命中即放行閘1）：
+#   - 長旗標：--message / --file / --template / --reuse-message / --reedit-message / --amend / --squash / --fixup
+#   - 短旗標（可成簇）：-m / -F / -t / -C / -c，含 -am / -sm 這種組合（簇內含 m/F/t/C 即算）
+# 都沒有 = 會開互動編輯器（agent/hook 情境＝空 commit 風險）→ 擋。
+HAS_MSG=0
+echo "$CMD" | grep -qE "(^|[[:space:]])--(message|file|template|reuse-message|reedit-message|amend|squash|fixup)([[:space:]=]|$)" && HAS_MSG=1
+# 短旗標簇：一個 dash 後接 a-zA-Z 簇且含 m/F/t/C/c（排除 -- 長旗標：用 [^-] 確保第一字元非 dash）
+echo "$CMD" | grep -qE "(^|[[:space:]])-[A-Za-z]*[mFtCc]" && HAS_MSG=1
+if [ "$HAS_MSG" -eq 0 ]; then
+  block "🔴 pre-commit-gate 閘1：git commit 沒帶 commit message（-m/-F/-t）。請用 git commit -m \"...\"，不要開互動編輯器空 commit。"
+fi
+
+# === 閘 2：staged diff 行數 ≤ 門檻 ===
+# 用 staged（--cached）的 numstat 加總 added+deleted；binary 檔 numstat 回 '-' 跳過不計。
+DIFF_LINES=$(cd "$CLAUDE_PROJECT_DIR" 2>/dev/null && git diff --cached --numstat 2>/dev/null \
+  | awk '$1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ {s+=$1+$2} END {print s+0}')
+DIFF_LINES=${DIFF_LINES:-0}
+if [ "$DIFF_LINES" -gt "$PRECOMMIT_MAX_DIFF" ]; then
+  block "🔴 pre-commit-gate 閘2：staged diff $DIFF_LINES 行 > 上限 $PRECOMMIT_MAX_DIFF 行。小步 PR 原則：拆成更小的 commit，或 export PRECOMMIT_MAX_DIFF=N 顯式放寬（請在 PR body 說明為何放寬）。"
+fi
+
+# === 閘 3：測試綠燈 ===
+# PRECOMMIT_TEST_CMD 未設 = 範本 / 還沒配測試 = skip-with-warning（不擋，否則種子 repo 無法 commit）。
+if [ -z "${PRECOMMIT_TEST_CMD:-}" ]; then
+  # warning 走 stderr，不影響 JSON 放行判定
+  echo "[pre-commit-gate] ⚠️ 閘3 跳過：未設 PRECOMMIT_TEST_CMD。fork 後請在 VERIFY.md 的『測試』指令設成此環境變數，commit 前才會真的跑測試。" >&2
+else
+  if ! ( cd "$CLAUDE_PROJECT_DIR" && eval "$PRECOMMIT_TEST_CMD" ) >/tmp/precommit-gate-test.log 2>&1; then
+    # 失敗軌跡持久化落地（issue #8）：必在 block 之前、且不得影響 block 判定。
+    # /tmp log 下次會被覆寫，這裡把它連同 staged diff / 指紋結構化存進 trajectories/。
+    capture_trajectory "$PRECOMMIT_TEST_CMD" "/tmp/precommit-gate-test.log"
+    TAIL=$(tail -n 15 /tmp/precommit-gate-test.log 2>/dev/null)
+    block "🔴 pre-commit-gate 閘3：測試未通過（指令：$PRECOMMIT_TEST_CMD）。修綠燈再 commit。
+（已存失敗軌跡到 .claude/trajectories/failures.jsonl）
+末尾輸出：
+$TAIL"
+  fi
+fi
+
+allow

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "agent-skills@addy-agent-skills": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-gate"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI (pytest on PR)
+
+# harness P1 前提件（spec ship-pr-until-green-harness §5 前提1）：
+# Ship-PR-Until-Green loop 需要一個「pull_request → main 跑全測試」的客觀達標信號。
+# 此 workflow 即該信號來源：每個對 main 的 PR / push 都跑 pytest，conclusion=success
+# 才算 loop「達標停」。在此之前 gov-bid-watch 只有 schedule/dispatch 的資料抓取
+# workflow（daily-watcher / weekly），沒有 PR 測試 CI。
+#
+# 只跑測試，不碰資料、不 push、不 deploy（純驗證，無不可逆動作）。
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run pytest
+        run: python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,17 @@ name: CI (pytest on PR)
 #
 # 只跑測試，不碰資料、不 push、不 deploy（純驗證，無不可逆動作）。
 
+# codex#3（第 2 輪）流程對齊：Ship-PR-Until-Green loop 的順序是「feature branch
+# 改 code → push feature → 等該 commit 的 CI 綠 → 才開 PR」。若 CI 只在 PR→main /
+# push→main 觸發，feature branch 還沒 PR 時就沒有 CI 信號，runner 會卡在
+# 「找不到本輪 SHA 的 run」→ STOP(3)。故 push 觸發放寬到所有分支：feature branch
+# 一 push 就跑 CI，runner 等的客觀信號實際會產生；PR→main 仍各自跑（含外部 fork PR）。
 on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches:
+      - "**"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ data/tmp_*.csv
 .claude/skills/using-agent-skills
 .claude/commands/
 .claude/settings.local.json
+.claude/harness/.state/

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -1,0 +1,29 @@
+# VERIFY — gov-bid-watch 驗證指令
+
+> harness 與人類自驗的單一指令來源。CI（`.github/workflows/ci.yml`）、
+> pre-commit-gate 閘3（`PRECOMMIT_TEST_CMD`）、獨立 verifier 全部對齊此檔。
+
+## 測試（全套）
+
+```bash
+python3 -m pytest -q
+```
+
+- 期望：全 passed（xfail 不算失敗）。目前 baseline：92 passed / 5 xfailed。
+- 此指令同時是：
+  - CI 在 `pull_request → main` 跑的內容（loop 達標的客觀信號）
+  - `PRECOMMIT_TEST_CMD` 應設成的值（commit 前閘3 本機快檢）
+  - 獨立 verifier 重跑「確認 CI 綠非環境僥倖」的內容
+
+## 安裝依賴
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+## pre-commit-gate 環境變數（harness loop 內 export）
+
+```bash
+export PRECOMMIT_TEST_CMD="python3 -m pytest -q"
+# 預設門檻沿用 hook 內建：PRECOMMIT_MAX_DIFF=150
+```

--- a/tests/test_harness_loop.py
+++ b/tests/test_harness_loop.py
@@ -1,15 +1,23 @@
 """harness ①Ship-PR-Until-Green loop 的退出語義回歸測試。
 
-驗 runner 的三層終止 / 不可逆邊界守門 exit code 契約穩定（spec §2.2/§2.3）：
-  exit 1 = FAIL（本機紅，回去改）
-  exit 2 = 拒絕（不可逆邊界：在受保護分支）
-  exit 3 = STOP（保險絲 / 無進展停，回報人）
-測試以子行程跑 runner，餵狀態檔模擬各情境，斷言 exit code。
-不觸發 push（所有情境停在 push 之前），故不依賴網路 / gh / remote。
+驗 runner 的三層終止 / 不可逆邊界守門 / 客觀 CI 信號 exit code 契約（spec §2.2/§2.3）：
+  exit 0 = PASS（本機綠 + 遠端 CI success，且 CI run 的 SHA==本輪 HEAD）
+  exit 1 = FAIL（本機紅 / push 失敗 / 遠端 CI 紅，回去改）
+  exit 2 = 拒絕（不可逆邊界：在受保護 / 非 feature 分支）
+  exit 3 = STOP（保險絲 / 無進展停 / 缺客觀 CI 信號，回報人）
+
+本檔含 codex 對抗審查指出原測試刻意避開的「最危險路徑」：
+  - CI 不可用 / 找不到本輪 SHA 的 run → 必須 STOP(3)，不可當綠 exit 0（#1）
+  - push 失敗 → 必須 FAIL(1)，不可吞 exit code（#2）
+  - 等的 CI run 的 SHA 必須 == 本輪 HEAD，舊 run 不算（#2）
+  - 受保護分支守門用白名單，env 不可繞過放行（#3）
+  - MAX_ITER off-by-one：「最多 8 輪」第 8 輪後即停（#7）
+測試以子行程跑 runner、用 PATH 前置 stub 攔截 git/gh，斷言 exit code。
 """
 import json
 import os
 import shutil
+import stat
 import subprocess
 import time
 from pathlib import Path
@@ -18,9 +26,23 @@ ROOT = Path(__file__).resolve().parent.parent
 RUNNER = ROOT / ".claude" / "harness" / "ship-pr-loop.sh"
 STATE_DIR = ROOT / ".claude" / "harness" / ".state"
 
+# 白名單內、會成功（綠）/失敗（紅）的本機測試命令。
+# 經 runner 的 `read -ra` 空白分詞 → argv，故參數內不可含空白。
+GREEN_CMD = "python3 --version"        # exit 0
+RED_CMD = "python3 -c raise"           # exit 1（raise 觸發 SyntaxError 仍非 0；穩定為紅）
 
-def _run(env_extra, iter0=0, scores=None):
-    """跑一輪 runner，回 (returncode, stderr)。scores=預灌分數歷史。"""
+
+def _write_stub(bindir: Path, name: str, body: str):
+    p = bindir / name
+    p.write_text("#!/usr/bin/env bash\n" + body + "\n")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(env_extra, iter0=0, scores=None, stub_git=None, stub_gh=None):
+    """跑一輪 runner，回 (returncode, stderr)。
+
+    scores=預灌分數歷史；stub_git/stub_gh=注入假 git/gh 的 bash body（攔截危險路徑）。
+    """
     if STATE_DIR.exists():
         shutil.rmtree(STATE_DIR)
     STATE_DIR.mkdir(parents=True)
@@ -29,30 +51,73 @@ def _run(env_extra, iter0=0, scores=None):
     )
     if scores:
         (STATE_DIR / "scores.log").write_text("\n".join(scores) + "\n")
+
     env = {**os.environ, **env_extra}
+
+    # 若要注入 stub，建一個臨時 bin 目錄前置到 PATH。
+    if stub_git or stub_gh:
+        import tempfile
+        bindir = Path(tempfile.mkdtemp(prefix="harness-stub-"))
+        real_git = shutil.which("git")
+        # git stub：未被攔截的子命令一律 delegate 真 git（runner 內部要用 rev-parse 等）
+        if stub_git is None:
+            stub_git = f'exec "{real_git}" "$@"'
+        _write_stub(bindir, "git", f'REAL_GIT="{real_git}"\n{stub_git}')
+        real_gh = shutil.which("gh") or "/usr/bin/false"
+        if stub_gh is None:
+            stub_gh = f'exec "{real_gh}" "$@"'
+        _write_stub(bindir, "gh", stub_gh)
+        env["PATH"] = f"{bindir}:{env.get('PATH','')}"
+
     p = subprocess.run(
         ["bash", str(RUNNER)], cwd=ROOT, env=env,
-        capture_output=True, text=True, timeout=60,
+        capture_output=True, text=True, timeout=90,
     )
     return p.returncode, p.stderr
 
+
+# ───────── 基本契約 ─────────
 
 def test_runner_exists_and_executable():
     assert RUNNER.exists(), "ship-pr-loop.sh 必須存在"
     assert os.access(RUNNER, os.X_OK), "runner 須可執行"
 
 
-def test_fuse_max_iter_stops():
-    # iter 已達上限，再跑一輪應 STOP(3)
-    rc, err = _run({"MAX_ITER": "2", "TEST_CMD": "false"}, iter0=2)
-    assert rc == 3, f"超過 MAX_ITER 應 exit 3，得 {rc}: {err}"
+def test_local_red_fails():
+    # 本機紅（白名單內命令 exit 1）、史不足 → FAIL(1)
+    rc, err = _run({"TEST_CMD": RED_CMD}, iter0=0)
+    assert rc == 1, f"本機紅應 exit 1，得 {rc}: {err}"
+    assert "FAIL" in err
+
+
+def test_test_cmd_whitelist_rejects_non_python():
+    # codex 建議：TEST_CMD 白名單。非 python/pytest 首字 → 拒絕(2)
+    rc, err = _run({"TEST_CMD": "rm -rf /tmp/should-not-run"}, iter0=0)
+    assert rc == 2, f"非白名單 TEST_CMD 應拒絕 exit 2，得 {rc}: {err}"
+    assert "白名單" in err
+
+
+# ───────── 保險絲：迭代上限（#7 off-by-one）─────────
+
+def test_fuse_max_iter_off_by_one():
+    # 「最多 MAX_ITER 輪」：已完成 MAX_ITER 輪後再呼叫即停，不可多跑一輪。
+    # iter0=2, MAX_ITER=2 → 已完成 2 輪 → 本次 STOP(3)，不該起第 3 輪。
+    rc, err = _run({"MAX_ITER": "2", "TEST_CMD": RED_CMD}, iter0=2)
+    assert rc == 3, f"達 MAX_ITER 應 exit 3（不多跑一輪），得 {rc}: {err}"
     assert "保險絲" in err
 
 
+def test_max_iter_allows_exactly_n_rounds():
+    # 邊界：已完成 MAX_ITER-1 輪 → 本次應正常起最後一輪（不被保險絲擋），落本機紅 FAIL(1)。
+    rc, err = _run({"MAX_ITER": "8", "TEST_CMD": RED_CMD}, iter0=7)
+    assert rc == 1, f"第 8 輪應正常執行（非保險絲），得 {rc}: {err}"
+
+
+# ───────── 無進展停 ─────────
+
 def test_no_progress_stops():
-    # 三輪同分(1,1,1)、本輪仍紅 → 無進展停(3)
     rc, err = _run(
-        {"NO_PROGRESS_N": "3", "MAX_ITER": "8", "TEST_CMD": "false"},
+        {"NO_PROGRESS_N": "3", "MAX_ITER": "8", "TEST_CMD": RED_CMD},
         iter0=0, scores=["1", "1"],
     )
     assert rc == 3, f"連續無進展應 exit 3，得 {rc}: {err}"
@@ -60,27 +125,108 @@ def test_no_progress_stops():
 
 
 def test_progress_does_not_false_stop():
-    # 分數在降(2,2,→1) 不應誤判無進展，落到本機紅 FAIL(1)
     rc, _ = _run(
-        {"NO_PROGRESS_N": "3", "TEST_CMD": "false"},
+        {"NO_PROGRESS_N": "3", "TEST_CMD": RED_CMD},
         iter0=0, scores=["2", "2"],
     )
-    assert rc == 1, f"分數有降應走 FAIL(1) 非 STOP，得 {rc}"
+    assert rc == 1, "分數有降應走 FAIL(1) 非 STOP"
 
 
-def test_local_red_fails():
-    # 首輪本機紅、史不足 → FAIL(1)
-    rc, err = _run({"TEST_CMD": "false"}, iter0=0)
-    assert rc == 1
-    assert "FAIL" in err
+# ───────── 不可逆邊界守門（#3 白名單）─────────
 
-
-def test_irreversible_branch_guard():
-    # 把當前分支設為受保護 → 拒絕(2)
-    cur = subprocess.run(
+def _cur_branch():
+    return subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
         cwd=ROOT, capture_output=True, text=True,
     ).stdout.strip()
-    rc, err = _run({"BRANCH_PREFIX_MAIN": cur}, iter0=0)
+
+
+def test_protected_branch_hard_block():
+    # PROTECTED_RE 命中當前分支 → 第一層硬擋(2)
+    cur = _cur_branch()
+    rc, err = _run({"PROTECTED_RE": f"^{cur}$"}, iter0=0)
     assert rc == 2, f"受保護分支應拒絕 exit 2，得 {rc}: {err}"
     assert "受保護分支" in err
+
+
+def test_non_feature_branch_blocked_by_whitelist():
+    # 白名單只允 feat/fix/... 開頭。把白名單收窄成不匹配當前分支 → 第二層擋(2)。
+    rc, err = _run({"ALLOWED_FEATURE_RE": "^nonexistent-prefix/.+"}, iter0=0)
+    assert rc == 2, f"非 feature 分支應拒絕 exit 2，得 {rc}: {err}"
+    assert "白名單" in err or "feature" in err
+
+
+def test_protected_block_not_bypassable_by_widening_whitelist():
+    # 即使把白名單放寬到 .*（想放行任何分支），PROTECTED_RE 第一層仍硬擋。
+    cur = _cur_branch()
+    rc, err = _run(
+        {"PROTECTED_RE": f"^{cur}$", "ALLOWED_FEATURE_RE": ".*"},
+        iter0=0,
+    )
+    assert rc == 2, f"放寬白名單不該繞過 PROTECTED_RE 硬擋，得 {rc}: {err}"
+    assert "受保護分支" in err
+
+
+# ───────── push 失敗（#2）─────────
+
+def test_push_failure_fails():
+    # 本機綠 → 進到 push；stub git 讓 push 失敗 → 必須 FAIL(1)，不可吞掉。
+    git_stub = '''
+case "$1" in
+  *) ;;
+esac
+# 攔截 push 子命令（可能帶 -C <root> 前綴）
+for a in "$@"; do
+  if [ "$a" = "push" ]; then echo "fatal: push rejected (stub)" >&2; exit 1; fi
+done
+exec "$REAL_GIT" "$@"
+'''
+    rc, err = _run({"TEST_CMD": GREEN_CMD}, iter0=0, stub_git=git_stub)
+    assert rc == 1, f"push 失敗應 exit 1，得 {rc}: {err}"
+    assert "push" in err
+
+
+# ───────── 缺客觀 CI 信號（#1）─────────
+
+def test_ci_unavailable_stops_not_pass():
+    # 本機綠 + push 成功(stub no-op) + gh 不可用 → 不可當綠 exit 0，必須 STOP(3)。
+    git_stub = '''
+for a in "$@"; do
+  if [ "$a" = "push" ]; then echo "stub push ok" >&2; exit 0; fi
+done
+exec "$REAL_GIT" "$@"
+'''
+    gh_stub = 'echo "gh stub: command not found path simulated" >&2; exit 127'
+    # 用「找不到 gh」的方式：把 gh stub 直接 exit 127 模擬不可用
+    rc, err = _run(
+        {"TEST_CMD": GREEN_CMD, "CI_POLL_TRIES": "2", "CI_POLL_SLEEP": "0"},
+        iter0=0, stub_git=git_stub, stub_gh=gh_stub,
+    )
+    # gh 存在但 run list 拿不到 run → return 2 → STOP(3)，不可當綠 exit 0
+    assert rc == 3, f"缺客觀 CI 信號應 STOP exit 3，不可當綠，得 {rc}: {err}"
+    assert "CI" in err
+
+
+def test_ci_run_sha_must_match_head():
+    # 本機綠 + push ok + gh run list 只回「舊 commit」的 run（headSha != HEAD）
+    #   → 找不到本輪 SHA 對應 run → return 2 → STOP(3)，不可拿舊綠當本輪成功。
+    git_stub = '''
+for a in "$@"; do
+  if [ "$a" = "push" ]; then echo "stub push ok" >&2; exit 0; fi
+done
+exec "$REAL_GIT" "$@"
+'''
+    # runner 用 `gh run list ... -q 'select(.headSha==$expect)'` 由 gh 自己過濾。
+    # 模擬：branch 上只有舊 commit 的 run，過濾後無匹配 → 回空。代表「找不到本輪 SHA 的 run」。
+    gh_stub = '''
+if [ "$1" = "run" ] && [ "$2" = "list" ]; then
+  echo ""   # select(headSha==本輪SHA) 過濾後無匹配（只有舊 run）
+  exit 0
+fi
+exit 0
+'''
+    rc, err = _run(
+        {"TEST_CMD": GREEN_CMD, "CI_POLL_TRIES": "2", "CI_POLL_SLEEP": "0"},
+        iter0=0, stub_git=git_stub, stub_gh=gh_stub,
+    )
+    assert rc == 3, f"CI run SHA 不符本輪 HEAD 應 STOP exit 3，得 {rc}: {err}"

--- a/tests/test_harness_loop.py
+++ b/tests/test_harness_loop.py
@@ -141,10 +141,26 @@ def _cur_branch():
     ).stdout.strip()
 
 
+def _run_on_branch(branch, env_extra, **kw):
+    """模擬「當前分支＝branch」跑 runner（驗受保護分支判定），不真的切 branch。
+
+    不能在 worktree 切到 main（main 被另一 worktree 佔用，checkout 會失敗並污染後續
+    測試）。改注入 git stub：攔 `rev-parse --abbrev-ref HEAD` 回假 branch 名，其餘
+    git 子命令 delegate 真 git。guard 只看 cur_branch 的輸出，這樣即可精準驗分支判定。
+    """
+    git_stub = (
+        'args="$*"\n'
+        'case "$args" in\n'
+        f'  *"rev-parse --abbrev-ref HEAD"*) echo "{branch}"; exit 0 ;;\n'
+        'esac\n'
+        'exec "$REAL_GIT" "$@"\n'
+    )
+    return _run(env_extra, stub_git=git_stub, **kw)
+
+
 def test_protected_branch_hard_block():
-    # PROTECTED_RE 命中當前分支 → 第一層硬擋(2)
-    cur = _cur_branch()
-    rc, err = _run({"PROTECTED_RE": f"^{cur}$"}, iter0=0)
+    # 在內建受保護分支 main 上 → 第一層內建硬擋(2)，不靠任何 env。
+    rc, err = _run_on_branch("main", {}, iter0=0)
     assert rc == 2, f"受保護分支應拒絕 exit 2，得 {rc}: {err}"
     assert "受保護分支" in err
 
@@ -156,14 +172,27 @@ def test_non_feature_branch_blocked_by_whitelist():
     assert "白名單" in err or "feature" in err
 
 
-def test_protected_block_not_bypassable_by_widening_whitelist():
-    # 即使把白名單放寬到 .*（想放行任何分支），PROTECTED_RE 第一層仍硬擋。
-    cur = _cur_branch()
-    rc, err = _run(
-        {"PROTECTED_RE": f"^{cur}$", "ALLOWED_FEATURE_RE": ".*"},
-        iter0=0,
-    )
-    assert rc == 2, f"放寬白名單不該繞過 PROTECTED_RE 硬擋，得 {rc}: {err}"
+def test_protected_block_not_bypassable_by_env_clearing_and_widening():
+    # ★ codex#3 第 2 輪假綠根因：上輪可用 PROTECTED_RE='^$' ALLOWED_FEATURE_RE='.*'
+    #   同時清空硬擋 + 放寬白名單，讓 main 兩層全繞過。
+    #   現在受保護判定錨在內建常數（env 動不了），這組 env 在 main/master 仍須拒絕(2)。
+    for b in ("main", "master"):
+        rc, err = _run_on_branch(
+            b,
+            {"PROTECTED_RE": "^$", "ALLOWED_FEATURE_RE": ".*",
+             "PROTECTED_EXTRA_RE": "^$"},
+            iter0=0,
+        )
+        assert rc == 2, (
+            f"env 清空+放寬不該繞過內建保護（branch={b}），得 {rc}: {err}")
+        assert "受保護分支" in err
+
+
+def test_protected_extra_re_can_only_tighten():
+    # env 只能「收緊」：PROTECTED_EXTRA_RE 可把額外分支（如 staging/x）也列為受保護。
+    rc, err = _run_on_branch(
+        "staging/x", {"PROTECTED_EXTRA_RE": "^staging/.*$"}, iter0=0)
+    assert rc == 2, f"PROTECTED_EXTRA_RE 追加保護應拒絕 exit 2，得 {rc}: {err}"
     assert "受保護分支" in err
 
 

--- a/tests/test_harness_loop.py
+++ b/tests/test_harness_loop.py
@@ -38,11 +38,34 @@ def _write_stub(bindir: Path, name: str, body: str):
     p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _run(env_extra, iter0=0, scores=None, stub_git=None, stub_gh=None):
+# 行為類測試的預設「當前分支」：注入白名單內的 feature 分支名，讓 guard_irreversible
+# 不依賴 CI 實際 checkout 的 git 分支。CI 的 actions/checkout 是 detached HEAD（branch
+# 名＝"HEAD"），不注入的話 guard 會在跑到目標斷言前就因「HEAD 非 feature 分支」exit 2，
+# 造成本機在 feat/ 分支綠、CI 卻紅的環境回歸。注入後行為測試在任何 checkout 都一致。
+DEFAULT_TEST_BRANCH = "feat/harness-test"
+
+
+def _run(env_extra, iter0=0, scores=None, stub_git=None, stub_gh=None,
+         stub_branch=None):
     """跑一輪 runner，回 (returncode, stderr)。
 
     scores=預灌分數歷史；stub_git/stub_gh=注入假 git/gh 的 bash body（攔截危險路徑）。
+
+    branch context 一律由測試控制、不吃 CI 的 detached HEAD：在任何 stub_git（含 caller
+    自帶的 push/run-list stub）前一律先攔 `rev-parse --abbrev-ref HEAD`。caller 未指定
+    branch → 回 DEFAULT_TEST_BRANCH（白名單內 feature 分支，讓行為測試跑到目標斷言）。
+    需驗特定分支判定的測試走 _run_on_branch，由它指定 branch。
     """
+    # 一律前置「分支攔截」：使 guard_irreversible 看到的分支由測試決定，不受 CI detached
+    # HEAD（branch 名＝"HEAD"）影響。caller 自帶的 stub_git 內容接在攔截之後（push/gh
+    # run-list 等仍走 caller 的攔截，其餘 delegate 真 git）。
+    branch = stub_branch or DEFAULT_TEST_BRANCH
+    branch_intercept = (
+        'case "$*" in\n'
+        f'  *"rev-parse --abbrev-ref HEAD"*) echo "{branch}"; exit 0 ;;\n'
+        'esac\n'
+    )
+    stub_git = branch_intercept + (stub_git or 'exec "$REAL_GIT" "$@"\n')
     if STATE_DIR.exists():
         shutil.rmtree(STATE_DIR)
     STATE_DIR.mkdir(parents=True)
@@ -145,17 +168,11 @@ def _run_on_branch(branch, env_extra, **kw):
     """模擬「當前分支＝branch」跑 runner（驗受保護分支判定），不真的切 branch。
 
     不能在 worktree 切到 main（main 被另一 worktree 佔用，checkout 會失敗並污染後續
-    測試）。改注入 git stub：攔 `rev-parse --abbrev-ref HEAD` 回假 branch 名，其餘
-    git 子命令 delegate 真 git。guard 只看 cur_branch 的輸出，這樣即可精準驗分支判定。
+    測試）。改用 _run 的 stub_branch 注入：攔 `rev-parse --abbrev-ref HEAD` 回指定
+    branch 名，其餘 git 子命令 delegate 真 git。guard 只看 cur_branch 的輸出，這樣即
+    可精準驗分支判定（亦不受 CI detached HEAD 影響）。
     """
-    git_stub = (
-        'args="$*"\n'
-        'case "$args" in\n'
-        f'  *"rev-parse --abbrev-ref HEAD"*) echo "{branch}"; exit 0 ;;\n'
-        'esac\n'
-        'exec "$REAL_GIT" "$@"\n'
-    )
-    return _run(env_extra, stub_git=git_stub, **kw)
+    return _run(env_extra, stub_branch=branch, **kw)
 
 
 def test_protected_branch_hard_block():

--- a/tests/test_harness_loop.py
+++ b/tests/test_harness_loop.py
@@ -1,0 +1,86 @@
+"""harness ①Ship-PR-Until-Green loop 的退出語義回歸測試。
+
+驗 runner 的三層終止 / 不可逆邊界守門 exit code 契約穩定（spec §2.2/§2.3）：
+  exit 1 = FAIL（本機紅，回去改）
+  exit 2 = 拒絕（不可逆邊界：在受保護分支）
+  exit 3 = STOP（保險絲 / 無進展停，回報人）
+測試以子行程跑 runner，餵狀態檔模擬各情境，斷言 exit code。
+不觸發 push（所有情境停在 push 之前），故不依賴網路 / gh / remote。
+"""
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RUNNER = ROOT / ".claude" / "harness" / "ship-pr-loop.sh"
+STATE_DIR = ROOT / ".claude" / "harness" / ".state"
+
+
+def _run(env_extra, iter0=0, scores=None):
+    """跑一輪 runner，回 (returncode, stderr)。scores=預灌分數歷史。"""
+    if STATE_DIR.exists():
+        shutil.rmtree(STATE_DIR)
+    STATE_DIR.mkdir(parents=True)
+    (STATE_DIR / "loop.json").write_text(
+        json.dumps({"iter": iter0, "start_ts": int(time.time())})
+    )
+    if scores:
+        (STATE_DIR / "scores.log").write_text("\n".join(scores) + "\n")
+    env = {**os.environ, **env_extra}
+    p = subprocess.run(
+        ["bash", str(RUNNER)], cwd=ROOT, env=env,
+        capture_output=True, text=True, timeout=60,
+    )
+    return p.returncode, p.stderr
+
+
+def test_runner_exists_and_executable():
+    assert RUNNER.exists(), "ship-pr-loop.sh 必須存在"
+    assert os.access(RUNNER, os.X_OK), "runner 須可執行"
+
+
+def test_fuse_max_iter_stops():
+    # iter 已達上限，再跑一輪應 STOP(3)
+    rc, err = _run({"MAX_ITER": "2", "TEST_CMD": "false"}, iter0=2)
+    assert rc == 3, f"超過 MAX_ITER 應 exit 3，得 {rc}: {err}"
+    assert "保險絲" in err
+
+
+def test_no_progress_stops():
+    # 三輪同分(1,1,1)、本輪仍紅 → 無進展停(3)
+    rc, err = _run(
+        {"NO_PROGRESS_N": "3", "MAX_ITER": "8", "TEST_CMD": "false"},
+        iter0=0, scores=["1", "1"],
+    )
+    assert rc == 3, f"連續無進展應 exit 3，得 {rc}: {err}"
+    assert "無進展" in err
+
+
+def test_progress_does_not_false_stop():
+    # 分數在降(2,2,→1) 不應誤判無進展，落到本機紅 FAIL(1)
+    rc, _ = _run(
+        {"NO_PROGRESS_N": "3", "TEST_CMD": "false"},
+        iter0=0, scores=["2", "2"],
+    )
+    assert rc == 1, f"分數有降應走 FAIL(1) 非 STOP，得 {rc}"
+
+
+def test_local_red_fails():
+    # 首輪本機紅、史不足 → FAIL(1)
+    rc, err = _run({"TEST_CMD": "false"}, iter0=0)
+    assert rc == 1
+    assert "FAIL" in err
+
+
+def test_irreversible_branch_guard():
+    # 把當前分支設為受保護 → 拒絕(2)
+    cur = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=ROOT, capture_output=True, text=True,
+    ).stdout.strip()
+    rc, err = _run({"BRANCH_PREFIX_MAIN": cur}, iter0=0)
+    assert rc == 2, f"受保護分支應拒絕 exit 2，得 {rc}: {err}"
+    assert "受保護分支" in err

--- a/tests/test_independent_verify.py
+++ b/tests/test_independent_verify.py
@@ -1,0 +1,117 @@
+"""harness ④Independent Verifier 的機械驗收 exit code 契約回歸測試。
+
+驗 independent-verify.sh 的達標判定（spec §3.3）：本機綠 AND 遠端 CI success。
+  exit 0 = 機械驗收過（本機綠 + CI 至少一個真 pass 且無 fail/pending）
+  exit 1 = 不過（本機紅 / CI 紅）
+  exit 2 = 未定論（CI pending / 全 skipping / 無 check / 未帶 PR / gh 不可用）
+
+本檔含 codex 第 2 輪 #4 指出的假綠根因：
+  「全是 skipping/neutral」原本被當 pass → 必須改判 UNKNOWN/FAIL，不可 exit 0。
+測試以子行程跑腳本、PATH 前置 stub 攔截 gh pr checks 的輸出，斷言 exit code。
+"""
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / ".claude" / "harness" / "independent-verify.sh"
+GREEN_CMD = "python3 --version"   # 本機綠
+RED_CMD = "python3 -c raise"      # 本機紅
+
+
+def _write_stub(bindir: Path, name: str, body: str):
+    p = bindir / name
+    p.write_text("#!/usr/bin/env bash\n" + body + "\n")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(pr_arg, test_cmd=GREEN_CMD, gh_checks_output=None):
+    """跑 independent-verify.sh，回 (returncode, stderr)。
+
+    gh_checks_output: 模擬 `gh pr checks` 的多行輸出（第二欄＝狀態），None＝不 stub gh。
+    """
+    env = {**os.environ, "TEST_CMD": test_cmd}
+    bindir = Path(tempfile.mkdtemp(prefix="iv-stub-"))
+    if gh_checks_output is not None:
+        # gh stub：只攔 `gh pr checks <PR>`，印出模擬的 checks 表（tab 分欄）。
+        # 其它 gh 子命令（如 command -v 探測）走 exit 0。
+        lines = "\n".join(gh_checks_output)
+        body = (
+            'if [ "$1" = "pr" ] && [ "$2" = "checks" ]; then\n'
+            f'  printf "%s\\n" "{lines}"\n'
+            '  exit 0\n'
+            'fi\n'
+            'exit 0\n'
+        )
+        _write_stub(bindir, "gh", body)
+        env["PATH"] = f"{bindir}:{env.get('PATH','')}"
+    args = ["bash", str(SCRIPT)]
+    if pr_arg is not None:
+        args.append(pr_arg)
+    p = subprocess.run(args, cwd=ROOT, env=env,
+                       capture_output=True, text=True, timeout=90)
+    return p.returncode, p.stderr
+
+
+def test_script_exists_executable():
+    assert SCRIPT.exists() and os.access(SCRIPT, os.X_OK)
+
+
+def test_local_red_fails():
+    # 本機紅 → 機械驗收不過(1)，連 CI 都不用看。
+    rc, err = _run(None, test_cmd=RED_CMD)
+    assert rc == 1, f"本機紅應 exit 1，得 {rc}: {err}"
+
+
+def test_no_pr_is_half_check_not_pass():
+    # 本機綠但未帶 PR 號＝只做本機半套，無遠端 CI 信號 → 非 0(2)，不可當完整驗收過。
+    rc, err = _run(None, test_cmd=GREEN_CMD)
+    assert rc == 2, f"未帶 PR 應半套 exit 2，得 {rc}: {err}"
+
+
+def test_real_pass_passes():
+    # 本機綠 + CI 至少一個真 pass、無 fail/pending → 機械驗收過(0)。
+    rc, err = _run("20", gh_checks_output=["pytest\tpass\t10s\thttp://x"])
+    assert rc == 0, f"真 pass 應 exit 0，得 {rc}: {err}"
+
+
+def test_ci_fail_fails():
+    rc, err = _run("20", gh_checks_output=["pytest\tfail\t10s\thttp://x"])
+    assert rc == 1, f"CI 紅應 exit 1，得 {rc}: {err}"
+
+
+def test_ci_pending_not_pass():
+    rc, err = _run("20", gh_checks_output=[
+        "pytest\tpass\t10s\thttp://x", "lint\tpending\t-\thttp://y"])
+    assert rc == 2, f"尚有 pending 應未定論 exit 2，得 {rc}: {err}"
+
+
+def test_all_skipping_is_not_pass():
+    # ★ codex#4 假綠根因：全 skipping（什麼都沒真跑）原被當 pass。必須改判未定論(2)。
+    rc, err = _run("20", gh_checks_output=[
+        "pytest\tskipping\t-\thttp://x", "lint\tskipping\t-\thttp://y"])
+    assert rc == 2, f"全 skipping 不可當綠，應 exit 2，得 {rc}: {err}"
+    assert "skipping" in err or "未定論" in err or "UNKNOWN" in err
+
+
+def test_all_neutral_is_not_pass():
+    # neutral 同 skipping：沒有任何一個真 pass → 不可放行。
+    rc, err = _run("20", gh_checks_output=["x\tneutral\t-\thttp://x"])
+    assert rc == 2, f"全 neutral 不可當綠，應 exit 2，得 {rc}: {err}"
+
+
+def test_no_check_is_not_pass():
+    # 有 PR 但完全沒 check（CI 未觸發）→ 未定論(2)。
+    rc, err = _run("20", gh_checks_output=[])
+    assert rc == 2, f"無 check 應 exit 2，得 {rc}: {err}"
+
+
+def test_pass_plus_skipping_still_passes():
+    # 至少一個真 pass + 其餘 skipping（無 fail/pending）→ 仍算 success(0)。
+    # （skipping 的 job 是矩陣裡沒命中的條件，不代表沒驗東西）
+    rc, err = _run("20", gh_checks_output=[
+        "pytest\tpass\t10s\thttp://x", "optional\tskipping\t-\thttp://y"])
+    assert rc == 0, f"有真 pass + skipping 應 exit 0，得 {rc}: {err}"


### PR DESCRIPTION
> Epic：jooca-tw/hyweb-sw-factory#94（spec）｜任務：jooca-tw/hyweb-sw-factory#105

## 改了什麼

依 sw-factory spec `ship-pr-until-green-harness` 實作 harness P1 兩件套，試點裝進 gov-bid-watch。

| 檔 | 作用 |
|----|------|
| `.github/workflows/ci.yml` | **新增** PR→main 跑 pytest 的 CI（harness 達標的客觀信號，spec §5 前提1）。原 repo 只有 schedule/dispatch 抓資料 workflow，無 PR 測試 CI |
| `.claude/harness/ship-pr-loop.sh` | ① Ship-PR-Until-Green runner：跑客觀信號(pytest)→push→等遠端 CI，三層終止(達標/保險絲/無進展)＋不可逆邊界守門 |
| `.claude/harness/independent-verify.sh` + `INDEPENDENT-VERIFIER.md` | ④ 獨立驗收：換 session 重驗，錨非 LLM 信號 |
| `.claude/harness/README.md` | 用法＋三層終止表＋不可逆邊界鐵則 |
| `.claude/hooks/pre-commit-gate` + `settings.json` | 帶入 sw-factory 既有 hook（message/diff≤150/測試綠 三閘，loop step3 ②commit前擋），掛 PreToolUse |
| `VERIFY.md` | 測試指令單一來源（`python3 -m pytest -q`） |
| `tests/test_harness_loop.py` | runner 退出語義回歸（exit 1/2/3 契約＋守門），同時是本次閉環試跑的真實小任務 |

## 保險絲預設（spec §8 拍板）
`MAX_ITER=8` / `NO_PROGRESS_N=3` / `MAX_WALL=60min`；`TOKEN_BUDGET` 試點期先收 baseline。

## 不可逆邊界（鐵則）
runner 只做可逆動作（append commit / push feature / 開 PR）。**禁** amend/rebase/force-push/push main/**auto-merge**——在受保護分支偵測會 exit 2。**merge 永遠人按**（本 PR 做到開 PR 為止）。

## 自驗
- 全套 pytest：98 passed / 5 xfailed（原 92 + 新 6）
- runner 自測：保險絲(MAX_ITER)、無進展停(同分3輪)、有進展不誤停、本機紅 FAIL、受保護分支守門 → exit code 全符契約
- macOS bash 3.2 無 `mapfile` → runner 改 portable 讀法（踩坑已修）

## ⚠️ 注意
- 動工全程在隔離 worktree + feature 分支，避開 gov-bid-watch 每日 08:00 data-commit 窗，未碰 main
- 本 PR 開完待 ④獨立驗收（換 session 派 qa-automation-architect）＋ Jay merge 前 codex 跨模型審查
- 注意 commit diff 較大者為 runner 本體（不可拆邏輯單元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)