### PR TITLE
以發布批次(filename)為錨做新案偵測＋斷糧告警，修正對不上官方2月延遲的查詢窗（#22 工項1）

### DIFF
--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -17,9 +17,9 @@ on:
     - cron: "0 0 * * *"   # 每日 08:00 台北（2026-06-13 啟用：webhook 已設 + P0 收緊勞務類）
   workflow_dispatch:
     inputs:
-      days:
-        description: "抓取天數（預設 2；每日跑只需近 2 天確保重疊）"
-        default: "2"
+      batches:
+        description: "抓最新 N 個發布批次（預設 3；issue #22 方案 A 批次錨）"
+        default: "3"
       push:
         description: "實際推 Slack？（true=推，預設 false=dry-run）"
         default: "false"
@@ -54,8 +54,10 @@ jobs:
           if [ -z "$TWINKLE_API_KEY" ]; then
             echo "::error::缺 secret TWINKLE_API_KEY"; exit 1
           fi
-          DAYS="${{ github.event.inputs.days || '2' }}"
-          python scripts/fetch_pcc.py --days "$DAYS" --out data/weekly.csv
+          # issue #22 方案 A：官方天生 ~2 月延遲 + 半月批次發布 → 用「最新批次」抓，
+          # 不再用 --days 公告日窗（對永遠落後 2 月的源結構性抓不到、天天 0 筆）。
+          BATCHES="${{ github.event.inputs.batches || '3' }}"
+          python scripts/fetch_pcc.py --latest-batches "$BATCHES" --out data/weekly.csv
 
       - name: Merge to master
         run: python scripts/merge.py --weekly data/weekly.csv --master data/bids.csv

--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -24,6 +24,13 @@ on:
         description: "實際推 Slack？（true=推，預設 false=dry-run）"
         default: "false"
 
+# #3 併發保護（issue #22）：schedule 與 manual dispatch 同時跑會各推一次 Slack、
+# 且兩輪各自讀寫 watcher_state.json 造成節流失效 / 水位競態。同一 workflow 同時
+# 只允許一輪；後到者排隊（不取消正在跑的，避免半途中斷推播/水位寫入）。
+concurrency:
+  group: daily-watcher
+  cancel-in-progress: false
+
 jobs:
   watch:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-watcher.yml
+++ b/.github/workflows/daily-watcher.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           # schedule 觸發（每日自動）→ 真推；手動 dispatch → 看 input（預設 dry-run）
           PUSH="${{ github.event.inputs.push || (github.event_name == 'schedule' && 'true' || 'false') }}"
-          ARGS="--weekly data/weekly.csv --state data/watcher_state.json"
+          # --master 開啟資料新鮮度檢查（issue #22）：上游斷糧時即使 0 筆也推 Slack 告警
+          ARGS="--weekly data/weekly.csv --state data/watcher_state.json --master data/bids.csv"
           if [ "$PUSH" = "true" ]; then ARGS="$ARGS --push"; fi
           # watcher capped 回 exit 2 → 標記但不讓整個 job 失敗（降級是正常路徑；
           # 時間封頂改靠本 step timeout-minutes 硬 kill，不再經 exit 2）

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,9 +16,9 @@ on:
     - cron: "0 0 * * 1"  # 每週一 08:00 台北（手動 dispatch 驗證成功後啟用）
   workflow_dispatch:
     inputs:
-      days:
-        description: "抓取天數（預設 14；pcc 為半月公開資料，14 天確保重疊）"
-        default: "14"
+      batches:
+        description: "抓最新 N 個發布批次（預設 3；issue #22 方案 A 批次錨）"
+        default: "3"
 
 jobs:
   fetch:
@@ -43,8 +43,9 @@ jobs:
             echo "::error::缺 secret TWINKLE_API_KEY（Settings → Secrets → Actions）"
             exit 1
           fi
-          DAYS="${{ github.event.inputs.days || '14' }}"
-          python scripts/fetch_pcc.py --days "$DAYS" --out data/weekly.csv
+          # issue #22 方案 A：以發布批次為錨抓，不用 --days 公告日窗（官方天生 2 月延遲）
+          BATCHES="${{ github.event.inputs.batches || '3' }}"
+          python scripts/fetch_pcc.py --latest-batches "$BATCHES" --out data/weekly.csv
 
       - name: Merge to master
         run: python scripts/merge.py --weekly data/weekly.csv --master data/bids.csv

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -9,7 +9,7 @@
 python3 -m pytest -q
 ```
 
-- 期望：全 passed（xfail 不算失敗）。目前 baseline：92 passed / 5 xfailed。
+- 期望：全 passed（xfail 不算失敗）。目前 baseline：130 passed / 5 xfailed。
 - 此指令同時是：
   - CI 在 `pull_request → main` 跑的內容（loop 達標的客觀信號）
   - `PRECOMMIT_TEST_CMD` 應設成的值（commit 前閘3 本機快檢）

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -73,10 +73,16 @@ PR #23 經 codex 獨立審查後，補以下 7 點（皆有回歸測試）：
    只在 `webhook is None` 才讀 env；明確傳 `""`＝不送（測試在有 `SLACK_WEBHOOK_URL`
    的環境也不會誤送真訊息）。
 
+8. **節流只在「真的送達」才啟動**（codex 複審）：原本只要 `should` 就設
+   `state["freshness_alert"]` + `alerted=True`，但 no_webhook / 送失敗其實沒推到
+   Slack，卻照樣消耗 3 天 realert 窗 → 告警被靜默壓掉、回到「靜默斷糧」。改為以
+   `notify_freshness()` 回傳 `sent=True` 為準才寫節流 / 標 alerted；沒送達仍寫
+   alert 檔留痕但不啟動節流，下輪重試推送。
+
 ## 影響
 
 - 不動 `fetch_pcc.py`（換源是 issue #22 工項 2/3，未拍板，本 PR 不碰）。
 - 新增 `scripts/freshness.py`（含 `taipei_today`）、`slack_notify.notify_freshness`、
   watcher `--master`/`--freshness-days`、`daily-watcher.yml` 加 `--master data/bids.csv`
   + `concurrency`。
-- 測試：全套 137 passed / 5 xfailed（`tests/test_freshness.py` 新增 7 點修正回歸）。
+- 測試：全套 138 passed / 5 xfailed（`tests/test_freshness.py` 含 7+1 點修正回歸）。

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -65,6 +65,28 @@ watcher 的新案偵測與新鮮度判斷都改用批次。
 7. webhook 空字串不 fallback env（測試環境不誤送）。
 8. 節流只在 `notify_freshness` 回傳 `sent=True` 才啟動（沒送達不消耗 realert 窗）。
 
+## 批次重寫的 codex 第三輪審查 5 點（2026-06-29 補）
+
+1. **dry-run 唯讀**（High）：dry-run 不再寫 alert / 不推進游標 / 不存 state（manual
+   dispatch 會把 state commit 回 repo，dry-run 推進游標會讓新批次被標已處理卻沒推 →
+   下次 schedule 同批不再推）。真跑時游標/水位**只在送達（sent=True 或本就 no_p0）
+   才推進**，送失敗不推進、下輪重抓重試。
+2. **批次缺口偵測**（High）：fetch 只抓最新 N 批，若 watcher 久停/mirror 一次補多批，
+   `cur_batch` 與游標期距 > 本輪實抓批次數 → 中間批次沒抓到。偵測到缺口寫 `batch_gap`
+   alert 提示人工 `--since` 回補，不靜默跳過。
+3. **非法批次值不污染**（Medium）：新增 `valid_batch_key`（過 `batch_period` 驗證），
+   `latest_batch` / `pick_latest_batch_keys` / 游標比較全改用合法 key，擋 half 03 /
+   月 13 等髒值灌頂排序或推進游標。
+4. **混合資料不靜默丟列**（Medium）：batch 模式下同份資料中無/非法 filename 的列
+   另走 seen_keys 水位法（不再只有「全部沒批次」才 fallback），免部分無 filename 的
+   列既不進 cand 也不走水位 → 永久不推。
+5. **壞游標降級**（Medium）：讀 state 的 `last_batch` 先驗 `batch_period`，非法
+   （舊格式/手改/merge 污染）→ 警告 + 重設基線，免合法新批次全判不出而靜默漏報。
+
+> ⚠️ 連帶語意變更：dry-run 改為**完全唯讀**（原 pilot 期 dry-run 會推進水位）。
+> drill_abort 改成直接 `commit_watermark` 種水位 + 真跑 capped 路徑（不呼叫 notify、
+> 無 webhook → 不推真 Slack）；相依的 watcher 測試改走真跑 + mock 送達。
+
 ## 取捨 / 替代方案
 
 - **沿用公告日距今**（初稿）：作廢——量錯對象，健康狀態天天誤報。
@@ -84,8 +106,9 @@ watcher 的新案偵測與新鮮度判斷都改用批次。
   新鮮度（`check_data_freshness`），state 新增 `last_batch`。
 - `slack_notify.py`：freshness payload 改批次語意（最新批次 / 預期批次 / 落後期數）。
 - `daily-watcher.yml`：fetch 改 `--latest-batches 3`、watcher 用 `--freshness-grace`。
-- 測試：全套 146 passed / 5 xfailed（`tests/test_freshness.py` 重寫為批次模型 +
-  `tests/test_fetch_batches.py` 批次抓取純函式）。
+- 測試：全套 152 passed / 5 xfailed（`tests/test_freshness.py` 批次模型 + 5 點修正回歸、
+  `tests/test_fetch_batches.py` 批次抓取純函式；`tests/test_watcher.py` / `drill_abort`
+  配合 dry-run 唯讀語意改真跑）。
 
 ## ⚠️ 待 CI 實測（本機無 token / MCP 不可用，無法在開發 session 驗）
 

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -1,88 +1,95 @@
-# ADR 0003：資料新鮮度告警（消滅「上游斷糧」靜默失敗）
+# ADR 0003：以「批次發布節奏」做新案偵測與斷糧告警
 
-- 狀態：已採納
+- 狀態：已採納（2026-06-29 根因翻轉後重做，取代初稿的「公告日距今」版）
 - 日期：2026-06-29
 - 關聯：issue #22、ADR 0002（watcher retry + 失敗告警）
 
-## 背景
+## 背景與根因翻轉
 
-daily watcher 每天只 fetch 近 2 天（`--days 2`）。上游 TwinkleAI `pcc-tender`
-mirror（政府電子採購網官方半月公開資料）約 2026-04 底起停止更新後，watcher
-本身完全正常，但每天抓回 0 筆 → `no_p0` → 不推 Slack。結果「上游斷糧」變成
-**靜默失敗**：看起來像「今天沒新標案」，沒人察覺資料源已死 56 天。
+最初症狀：daily watcher 每天 `fetch_pcc.py --days 2`（抓近 2 天公告日）→ 天天 0 筆
+→ `no_p0` → 不推 Slack，看起來像「上游斷糧」靜默失敗。
 
-ADR 0002 的失敗告警只覆蓋「run 拋錯」；「成功跑但永遠 0 筆」不在其守備範圍。
+初稿（本 ADR 第一版）判成「資料源斷糧、用公告日距今 14 天告警」。**但實證推翻了
+這個前提**：
 
-## 決策
+1. 官方政府電子採購網開放資料頁逐字寫明「**每個月 5 號會產出 2 個月前的資料**」
+   → 官方**天生延遲 ~2 個月**。今天（2026-06-29）官方最新批次就是
+   `tender_20260402.xml`（4 月下半月），無 5/6 月檔屬正常。
+2. 資料以「**半月批次檔**」發布，檔名 `tender_YYYYMM0H.xml` / `award_YYYYMM0H.xml`
+   （末 2 碼 0H＝半月期別 01/02，**不是日**）。
+3. `date` 欄是標案公告/截止日（可未來），**不等於發布時點**——同一個 `tender_20260302`
+   批次裡混有 2026-05、甚至 09 的 date。
 
-watcher 每輪額外做一道**資料新鮮度檢查**（與 P0 推播流程獨立）：
+→ 結論：
+- watcher 用「公告日最近 2 天」對一個永遠落後 ~2 月的源，**結構性抓不到**，0 筆是必然。
+- 用「公告日距今 14 天」量新鮮度會**天天誤報**（健康狀態資料本就 ~60 天舊）。
+- 換源直連官方（原工項 3）也救不了——官方一樣延遲 2 月。
 
-- 判斷依據＝**master `data/bids.csv` 的最大 `date`**（非本輪 weekly）。斷糧時
-  weekly 為空，但 master 最大日期會卡在最後一次有料日；供料恢復後隨 merge 前進、
-  停滯天數自動歸零 → 不誤報。
-- `today - 最大date > N 天` → 寫 `data/alerts/*-data_freshness.json` + 推一則
-  Slack 告警（含資料源 / 最新日期 / 距今天數）。
-- 沿用既有 Slack 路徑與 dry-run / no-webhook 安全降級語意（同 `notify`）。
-- 只在 `--master` 有給時啟用，保護既有 P0 流程與舊測試。
+## 決策：一切以 `filename` 批次為錨
 
-## N（門檻）為何取 14 天，而非 issue brief 初估的 3–5
+唯一可靠的「發布批次」訊號是 `filename`。fetch 層把 `filename` 帶進 schema，
+watcher 的新案偵測與新鮮度判斷都改用批次。
 
-pcc-tender 是「半月公開」資料，**正常供料下最新日期本就會落後**。實測健康期
-（2026 Jan–Apr）master：有料日多為每日/每 1–3 天，但農曆年假期出現過最大
-**10 天**資料空窗（2/13→2/23）；疊加半月發布節奏，下次發布前最新日期可正常
-落後到 ~16 天。
+**批次識別**（`freshness.batch_key`）：取 filename 的 8 碼日期段 `YYYYMM0H`，
+跨 tender_/award_ 前綴統一用日期段比較（避免前綴字典序混比）。
+`batch_period` 把 `YYYYMM0H` 轉成連續半月期序號（相鄰半月差 1）方便比節奏。
 
-- 取 3–5 → 每逢假期/發布前空窗就誤報 → 違反「正常供料不誤報」鐵則。狼來了
-  喊久被無視 ＝ 退回靜默失敗，得不償失。
-- 取 14 ＝ 大於實測最壞正常空窗（10）+ 裕度，仍能在再次斷糧後約兩週內告警；
-  當前已斷糧 56 天 → 立即觸發。
-- 可由 `--freshness-days` 覆寫，Jay 可隨上游節奏調整。
+### 1. 新案偵測（取代 `--days 2` 公告日窗）
+- fetch：`fetch_pcc.py --latest-batches N`，先 group_by filename 取最新 N 個批次、
+  再抓那幾批的軟體類案（workflow 預設 N=3）。
+- watcher：state 記 `last_batch`（已處理過的最新批次日期段）。每輪只把
+  **批次 > last_batch** 的案子當新案做 P0 篩選 + 推 Slack，處理後推進 last_batch。
+- **冷啟動基線**：state 從未記過 last_batch → 只設基線、不回補整個歷史 backlog
+  （否則首輪湧入數千案必觸成本封頂），本輪不推。
+- **無批次訊號 fallback**：若 rows 完全沒有 filename（非 pcc / 舊資料 / drill 合成
+  資料）→ 退回既有 seen_keys 水位法，向後相容。
 
-並加重提節流（`FRESHNESS_REALERT_DAYS=3`）：首次偵測立即推，之後同一停滯狀態
-每 3 天才重提一次，避免長期斷糧每天轟炸 Slack；恢復供料後清節流，再斷糧能立即重提。
+### 2. 斷糧告警（取代公告日距今）
+- `freshness.check_batch_freshness`：比較「資料源最新批次」與「依官方節奏應有的
+  最新批次」。官方每月約 5 號發布 2 月前整月 → 預期最新到「今天 -2 月」的下半月
+  （5 號前保守抓 -3 月）。落後超過 `grace_periods` 個半月期 → 判真斷糧。
+- `grace_periods` 預設 **1**：容忍落後 1 個半月期（某半月剛好還沒發的正常時點差），
+  落後 ≥2 期才告警 → 不把「正常半月延遲」誤報成斷糧。
+- 實證（2026-06-29）：TwinkleAI 最新批次 `20260302`、預期 `20260402` → 落後 **2 期**
+  → 正當觸發告警（**非誤報**，TwinkleAI mirror 確實缺 4 月、落後官方 2 批次）。
+
+## 保留 PR #23 已修好的健壯性（codex 兩輪審查）
+
+判準從「公告日」改「批次」，但下列防護沿用、改成批次語意：
+1. dry-run 只回報 `would_alert`，不寫 alert 檔、不更新節流 state。
+2. 壞掉的節流紀錄（last_alert_date 非法）不丟例外，視為無節流續推。
+3. workflow `concurrency` 防 schedule×dispatch 雙推 / state 競態。
+4. 批次/節流節點忽略非法值（batch_period 拒 13 月、03 半月等髒值）。
+5. master 讀取/檢查失敗只降級 warning，不中斷既有 P0 推播。
+6. 一律用 `Asia/Taipei` 日界線（影響發布日 5 號邊界判斷）。
+7. webhook 空字串不 fallback env（測試環境不誤送）。
+8. 節流只在 `notify_freshness` 回傳 `sent=True` 才啟動（沒送達不消耗 realert 窗）。
 
 ## 取捨 / 替代方案
 
-- **改用「連續 N 天 fetched=0」訊號**：對半月節奏更穩，但語意較間接、且與
-  issue 要求的「最新日期 > N 天」不一致。最終選日期-age（直觀、可在告警直接讀出
-  停滯天數），半月節奏的誤報風險用提高 N（14）吸收。
-- **拿 weekly 當新鮮度依據**：錯——斷糧時 weekly 恆空，無法區分「今天剛好無新案」
-  與「上游已死」。必須看 master 累積最大日期。
-
-## 健壯性修正（codex 跨模型審查 7 點，2026-06-29 補）
-
-PR #23 經 codex 獨立審查後，補以下 7 點（皆有回歸測試）：
-
-1. **dry-run 不消耗節流/不寫檔**（High）：原 dry-run 仍 `write_alert` + 更新
-   `state["freshness_alert"]`，手動 dry-run 後真推會被 `realert_days` 壓掉。改為
-   dry-run 只回報 `would_alert`，不落檔、不動 state。
-2. **壞掉的節流 state 不讓整輪 crash**（High）：`strptime(last_alert_date)` 包
-   try/except，異常 state（空字串/舊格式/殘留）視為「無有效節流」續推，不在 P0
-   diff/notify 前丟例外。
-3. **workflow 併發保護**（High）：`daily-watcher.yml` 加 `concurrency` group，
-   schedule 與 manual dispatch 不再各推一次、不再競態讀寫 state。
-4. **未來日期不遮蔽告警**（Medium）：`latest_data_date(today=...)` 忽略
-   `> today` 的髒行（如 `20991231`），避免成為最大日期使 age 變負、stale=False
-   遮蔽真斷糧。
-5. **master 讀取失敗只降級不中斷 P0**（Medium）：`run()` 把新鮮度檢查包
-   try/except，master 不存在/路徑錯/編碼錯 → 印 warning + `freshness={"error":...}`，
-   既有 P0 推播照常跑完。
-6. **時區明確用 Asia/Taipei**（Medium）：新增 `taipei_today()`，取代 runner UTC
-   的 `date.today()`，避免台北凌晨排程在 14 天門檻附近差 1 天誤判。
-7. **webhook 空字串不 fallback env**（Medium）：`notify`/`notify_freshness` 改為
-   只在 `webhook is None` 才讀 env；明確傳 `""`＝不送（測試在有 `SLACK_WEBHOOK_URL`
-   的環境也不會誤送真訊息）。
-
-8. **節流只在「真的送達」才啟動**（codex 複審）：原本只要 `should` 就設
-   `state["freshness_alert"]` + `alerted=True`，但 no_webhook / 送失敗其實沒推到
-   Slack，卻照樣消耗 3 天 realert 窗 → 告警被靜默壓掉、回到「靜默斷糧」。改為以
-   `notify_freshness()` 回傳 `sent=True` 為準才寫節流 / 標 alerted；沒送達仍寫
-   alert 檔留痕但不啟動節流，下輪重試推送。
+- **沿用公告日距今**（初稿）：作廢——量錯對象，健康狀態天天誤報。
+- **換源直連官方**（原工項 3）：暫不做——官方一樣 2 月延遲，換源不解決查詢窗問題；
+  且官方下載有 Cloudflare 反爬（當初繞道 TwinkleAI 正為此）。TwinkleAI 落後官方
+  2 批次的事另議（催 mirror 或日後換源）。
+- **用 `date` 推批次**：錯——date 可未來、與批次不對應（同批次混多月 date）。
 
 ## 影響
 
-- 不動 `fetch_pcc.py`（換源是 issue #22 工項 2/3，未拍板，本 PR 不碰）。
-- 新增 `scripts/freshness.py`（含 `taipei_today`）、`slack_notify.notify_freshness`、
-  watcher `--master`/`--freshness-days`、`daily-watcher.yml` 加 `--master data/bids.csv`
-  + `concurrency`。
-- 測試：全套 138 passed / 5 xfailed（`tests/test_freshness.py` 含 7+1 點修正回歸）。
+- `fetch_pcc.py`：COLS/OUT_FIELDS/map_row 加 `filename`；新增 `--latest-batches`
+  批次抓取（`fetch_batches` / `latest_batch_keys` / `pick_latest_batch_keys`）；
+  `MCP.query_rows` 支援 order_by/group_by。
+- `freshness.py`：改為批次模型（`batch_key`/`batch_period`/`period_to_key`/
+  `latest_batch`/`expected_latest_batch_period`/`check_batch_freshness` + `taipei_today`）。
+- `watcher.py`：批次新案偵測（`find_new_by_batch`，含 baseline/fallback）+ 批次
+  新鮮度（`check_data_freshness`），state 新增 `last_batch`。
+- `slack_notify.py`：freshness payload 改批次語意（最新批次 / 預期批次 / 落後期數）。
+- `daily-watcher.yml`：fetch 改 `--latest-batches 3`、watcher 用 `--freshness-grace`。
+- 測試：全套 146 passed / 5 xfailed（`tests/test_freshness.py` 重寫為批次模型 +
+  `tests/test_fetch_batches.py` 批次抓取純函式）。
+
+## ⚠️ 待 CI 實測（本機無 token / MCP 不可用，無法在開發 session 驗）
+
+`--latest-batches` 對真 TwinkleAI 的抓取需在 CI（有 `TWINKLE_API_KEY`）或可存取
+MCP 的環境驗一次：確認 `latest_batch_keys` 真能取回最新批次、`fetch_batches`
+的 `filename ILIKE '%YYYYMM0H%'` 抓得到該批案子。協調者已用 MCP 確認：filename
+欄存在且有值、TwinkleAI 最新 `tender_20260302`、官方已 `tender_20260402`。

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -1,0 +1,57 @@
+# ADR 0003：資料新鮮度告警（消滅「上游斷糧」靜默失敗）
+
+- 狀態：已採納
+- 日期：2026-06-29
+- 關聯：issue #22、ADR 0002（watcher retry + 失敗告警）
+
+## 背景
+
+daily watcher 每天只 fetch 近 2 天（`--days 2`）。上游 TwinkleAI `pcc-tender`
+mirror（政府電子採購網官方半月公開資料）約 2026-04 底起停止更新後，watcher
+本身完全正常，但每天抓回 0 筆 → `no_p0` → 不推 Slack。結果「上游斷糧」變成
+**靜默失敗**：看起來像「今天沒新標案」，沒人察覺資料源已死 56 天。
+
+ADR 0002 的失敗告警只覆蓋「run 拋錯」；「成功跑但永遠 0 筆」不在其守備範圍。
+
+## 決策
+
+watcher 每輪額外做一道**資料新鮮度檢查**（與 P0 推播流程獨立）：
+
+- 判斷依據＝**master `data/bids.csv` 的最大 `date`**（非本輪 weekly）。斷糧時
+  weekly 為空，但 master 最大日期會卡在最後一次有料日；供料恢復後隨 merge 前進、
+  停滯天數自動歸零 → 不誤報。
+- `today - 最大date > N 天` → 寫 `data/alerts/*-data_freshness.json` + 推一則
+  Slack 告警（含資料源 / 最新日期 / 距今天數）。
+- 沿用既有 Slack 路徑與 dry-run / no-webhook 安全降級語意（同 `notify`）。
+- 只在 `--master` 有給時啟用，保護既有 P0 流程與舊測試。
+
+## N（門檻）為何取 14 天，而非 issue brief 初估的 3–5
+
+pcc-tender 是「半月公開」資料，**正常供料下最新日期本就會落後**。實測健康期
+（2026 Jan–Apr）master：有料日多為每日/每 1–3 天，但農曆年假期出現過最大
+**10 天**資料空窗（2/13→2/23）；疊加半月發布節奏，下次發布前最新日期可正常
+落後到 ~16 天。
+
+- 取 3–5 → 每逢假期/發布前空窗就誤報 → 違反「正常供料不誤報」鐵則。狼來了
+  喊久被無視 ＝ 退回靜默失敗，得不償失。
+- 取 14 ＝ 大於實測最壞正常空窗（10）+ 裕度，仍能在再次斷糧後約兩週內告警；
+  當前已斷糧 56 天 → 立即觸發。
+- 可由 `--freshness-days` 覆寫，Jay 可隨上游節奏調整。
+
+並加重提節流（`FRESHNESS_REALERT_DAYS=3`）：首次偵測立即推，之後同一停滯狀態
+每 3 天才重提一次，避免長期斷糧每天轟炸 Slack；恢復供料後清節流，再斷糧能立即重提。
+
+## 取捨 / 替代方案
+
+- **改用「連續 N 天 fetched=0」訊號**：對半月節奏更穩，但語意較間接、且與
+  issue 要求的「最新日期 > N 天」不一致。最終選日期-age（直觀、可在告警直接讀出
+  停滯天數），半月節奏的誤報風險用提高 N（14）吸收。
+- **拿 weekly 當新鮮度依據**：錯——斷糧時 weekly 恆空，無法區分「今天剛好無新案」
+  與「上游已死」。必須看 master 累積最大日期。
+
+## 影響
+
+- 不動 `fetch_pcc.py`（換源是 issue #22 工項 2/3，未拍板，本 PR 不碰）。
+- 新增 `scripts/freshness.py`、`slack_notify.notify_freshness`、watcher `--master`/
+  `--freshness-days`、`daily-watcher.yml` 加 `--master data/bids.csv`。
+- 測試 baseline：92 → 105+（新增 `tests/test_freshness.py`）。

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -49,9 +49,34 @@ pcc-tender 是「半月公開」資料，**正常供料下最新日期本就會�
 - **拿 weekly 當新鮮度依據**：錯——斷糧時 weekly 恆空，無法區分「今天剛好無新案」
   與「上游已死」。必須看 master 累積最大日期。
 
+## 健壯性修正（codex 跨模型審查 7 點，2026-06-29 補）
+
+PR #23 經 codex 獨立審查後，補以下 7 點（皆有回歸測試）：
+
+1. **dry-run 不消耗節流/不寫檔**（High）：原 dry-run 仍 `write_alert` + 更新
+   `state["freshness_alert"]`，手動 dry-run 後真推會被 `realert_days` 壓掉。改為
+   dry-run 只回報 `would_alert`，不落檔、不動 state。
+2. **壞掉的節流 state 不讓整輪 crash**（High）：`strptime(last_alert_date)` 包
+   try/except，異常 state（空字串/舊格式/殘留）視為「無有效節流」續推，不在 P0
+   diff/notify 前丟例外。
+3. **workflow 併發保護**（High）：`daily-watcher.yml` 加 `concurrency` group，
+   schedule 與 manual dispatch 不再各推一次、不再競態讀寫 state。
+4. **未來日期不遮蔽告警**（Medium）：`latest_data_date(today=...)` 忽略
+   `> today` 的髒行（如 `20991231`），避免成為最大日期使 age 變負、stale=False
+   遮蔽真斷糧。
+5. **master 讀取失敗只降級不中斷 P0**（Medium）：`run()` 把新鮮度檢查包
+   try/except，master 不存在/路徑錯/編碼錯 → 印 warning + `freshness={"error":...}`，
+   既有 P0 推播照常跑完。
+6. **時區明確用 Asia/Taipei**（Medium）：新增 `taipei_today()`，取代 runner UTC
+   的 `date.today()`，避免台北凌晨排程在 14 天門檻附近差 1 天誤判。
+7. **webhook 空字串不 fallback env**（Medium）：`notify`/`notify_freshness` 改為
+   只在 `webhook is None` 才讀 env；明確傳 `""`＝不送（測試在有 `SLACK_WEBHOOK_URL`
+   的環境也不會誤送真訊息）。
+
 ## 影響
 
 - 不動 `fetch_pcc.py`（換源是 issue #22 工項 2/3，未拍板，本 PR 不碰）。
-- 新增 `scripts/freshness.py`、`slack_notify.notify_freshness`、watcher `--master`/
-  `--freshness-days`、`daily-watcher.yml` 加 `--master data/bids.csv`。
-- 測試 baseline：92 → 105+（新增 `tests/test_freshness.py`）。
+- 新增 `scripts/freshness.py`（含 `taipei_today`）、`slack_notify.notify_freshness`、
+  watcher `--master`/`--freshness-days`、`daily-watcher.yml` 加 `--master data/bids.csv`
+  + `concurrency`。
+- 測試：全套 137 passed / 5 xfailed（`tests/test_freshness.py` 新增 7 點修正回歸）。

--- a/docs/adr/0003-data-freshness-alert.md
+++ b/docs/adr/0003-data-freshness-alert.md
@@ -79,7 +79,9 @@ watcher 的新案偵測與新鮮度判斷都改用批次。
    月 13 等髒值灌頂排序或推進游標。
 4. **混合資料不靜默丟列**（Medium）：batch 模式下同份資料中無/非法 filename 的列
    另走 seen_keys 水位法（不再只有「全部沒批次」才 fallback），免部分無 filename 的
-   列既不進 cand 也不走水位 → 永久不推。
+   列既不進 cand 也不走水位 → 永久不推。**複審補**：`find_new_by_batch` 回傳
+   `commit_rows = cand + no_batch`，送達後 `_persist` 把 no_batch 列也寫入水位，
+   否則本輪推了下輪又重推、`new` 每輪膨脹。
 5. **壞游標降級**（Medium）：讀 state 的 `last_batch` 先驗 `batch_period`，非法
    （舊格式/手改/merge 污染）→ 警告 + 重設基線，免合法新批次全判不出而靜默漏報。
 

--- a/scripts/drill_abort.py
+++ b/scripts/drill_abort.py
@@ -58,10 +58,12 @@ def run_drill():
     _write_csv(csvp, rows)
 
     try:
-        # 1. 建穩定水位：先跑一輪把全部收進水位（dry-run）
-        watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+        # 1. 建穩定水位：直接把全部列收進水位（dry-run 現為唯讀、不持久化，
+        #    故改直接 commit_watermark 種水位，模擬已穩定運行的 watcher）。
         st = load_state(statep)
-        baseline_run = watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+        commit_watermark(rows, st)
+        save_state(st, statep)
+        baseline_run = watcher.run(csvp, statep, dry_run=False, push_cap=PUSH_CAP)
         assert baseline_run["new"] == 0, "穩定態應 0 新出現"
 
         # 2. 跑偏：回退水位（刪掉全部 seen → 舊案重新變新）
@@ -70,8 +72,9 @@ def run_drill():
         save_state(st, statep)
         print(f"[drill] 水位回退 {removed} 筆（模擬跑偏/資料異常）", file=sys.stderr)
 
-        # 3. 再跑一輪 → 應觸發封頂
-        res = watcher.run(csvp, statep, dry_run=True, push_cap=PUSH_CAP)
+        # 3. 再跑一輪 → 應觸發封頂（dry_run=False；capped 路徑不呼叫 notify，
+        #    無 webhook → 不會推真 Slack，演練安全）
+        res = watcher.run(csvp, statep, dry_run=False, push_cap=PUSH_CAP)
 
         # 4. 斷言
         assert res["status"] == "capped", f"應觸發封頂，實得 {res['status']}"

--- a/scripts/fetch_pcc.py
+++ b/scripts/fetch_pcc.py
@@ -35,7 +35,7 @@ from tenacity import (
 
 # 軟體開發類過濾規則沿用 g0v fetcher（單一事實源，不重複維護）
 from fetch_bids import BLACKLIST, KEYWORDS, pre_filter  # noqa: E402
-from freshness import batch_key  # noqa: E402 — 批次日期段擷取（issue #22 方案 A）
+from freshness import valid_batch_key  # noqa: E402 — 合法批次日期段（issue #22 方案 A）
 
 
 # ---------- 暫時性錯誤 → 觸發 retry（永久性錯誤不重試，免燒配額）----------
@@ -257,9 +257,10 @@ def _month_windows(since, until):
 def pick_latest_batch_keys(filenames, n):
     """從一堆 filename 取最新 n 個不同批次日期段（'YYYYMM0H'，新→舊）。
 
-    純函式（無網路）：跨 tender_/award_ 前綴用 batch_key 統一成日期段去重再排序。
+    純函式（無網路）：跨 tender_/award_ 前綴統一成日期段、**只取合法批次**（擋
+    half 03 / 月 13 等髒值，codex #3）、去重再排序。
     """
-    keys = {bk for f in filenames if (bk := batch_key(f))}
+    keys = {bk for f in filenames if (bk := valid_batch_key(f))}
     return sorted(keys, reverse=True)[:n]
 
 

--- a/scripts/fetch_pcc.py
+++ b/scripts/fetch_pcc.py
@@ -35,6 +35,7 @@ from tenacity import (
 
 # 軟體開發類過濾規則沿用 g0v fetcher（單一事實源，不重複維護）
 from fetch_bids import BLACKLIST, KEYWORDS, pre_filter  # noqa: E402
+from freshness import batch_key  # noqa: E402 — 批次日期段擷取（issue #22 方案 A）
 
 
 # ---------- 暫時性錯誤 → 觸發 retry（永久性錯誤不重試，免燒配額）----------
@@ -82,11 +83,13 @@ COUNTY_CODE = {
 }
 
 # 要從 pcc-tender 撈的欄位
+# filename（issue #22 方案 A）：批次檔名（如 tender_20260402.xml），唯一可靠的
+#   「發布批次」識別——date 是公告/截止日（可未來），不能當批次/新鮮度依據。
 COLS = [
     "date", "announcement_type", "title", "agency", "agency_id", "job_number",
     "companies", "detail_url", "notice_date", "procurement_type", "procurement_attr",
     "award_way", "award_price", "contact_phone", "contact_person",
-    "agency_county_code", "agency_town_code", "not_obtain_supp_name",
+    "agency_county_code", "agency_town_code", "not_obtain_supp_name", "filename",
 ]
 
 
@@ -144,10 +147,13 @@ class MCP:
                     pass
         return out
 
-    def query_rows(self, where, columns, limit, offset=0, retries=4):
+    def query_rows(self, where, columns, limit, offset=0, retries=4,
+                   order_by="date DESC", group_by=None):
         rid = self._next()
         args = {"dataset_id": DATASET, "where": where, "columns": columns,
-                "limit": limit, "offset": offset, "order_by": "date DESC"}
+                "limit": limit, "offset": offset, "order_by": order_by}
+        if group_by:
+            args["group_by"] = group_by
         last_res = None
         for i in range(retries):
             # 工具名 = query_rows（TwinkleAI 2026 改版已去掉 opendata- prefix；
@@ -230,6 +236,7 @@ def map_row(rec):
         "contact_person": rec.get("contact_person") or "",
         "contact_phone": rec.get("contact_phone") or "",
         "losing_supplier": rec.get("not_obtain_supp_name") or "",
+        "filename": rec.get("filename") or "",   # 批次識別（issue #22 方案 A）
     }
 
 
@@ -245,6 +252,66 @@ def _month_windows(since, until):
         wins.append((cur.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")))
         cur = nxt
     return wins
+
+
+def pick_latest_batch_keys(filenames, n):
+    """從一堆 filename 取最新 n 個不同批次日期段（'YYYYMM0H'，新→舊）。
+
+    純函式（無網路）：跨 tender_/award_ 前綴用 batch_key 統一成日期段去重再排序。
+    """
+    keys = {bk for f in filenames if (bk := batch_key(f))}
+    return sorted(keys, reverse=True)[:n]
+
+
+def latest_batch_keys(mcp, n):
+    """查資料源最新 n 個批次日期段（issue #22 方案 A）。
+
+    group_by filename 取所有檔名（半月批次數量有限、遠低於 5000），再抽日期段。
+    """
+    d = mcp.query_rows("filename IS NOT NULL", ["filename"], MONTH_LIMIT,
+                       order_by="filename DESC", group_by=["filename"])
+    cols, rows = d.get("columns", []), d.get("rows", [])
+    fi = cols.index("filename") if "filename" in cols else 0
+    files = [r[fi] for r in rows if r]
+    return pick_latest_batch_keys(files, n)
+
+
+def fetch_batches(token, n_batches):
+    """抓資料源最新 n_batches 個批次的軟體類案子（issue #22 方案 A）。
+
+    取代「公告日最近 N 天」窗：資料源永遠落後 ~2 月、date 還可能是未來/截止日，
+    用公告日窗結構性抓不到。改以批次檔（filename）為錨抓最新幾批。
+    """
+    mcp = MCP(token)
+    kw = _kw_clause()
+    keys = latest_batch_keys(mcp, n_batches)
+    print(f"=== fetch pcc-tender 最新 {n_batches} 批次：{keys} ===", file=sys.stderr)
+    rows, seen, dropped_bl = [], set(), 0
+    for bk in keys:
+        # 同一批次跨 tender_/award_ 兩個檔名 → 用日期段 ILIKE 一網打盡
+        where = (f"filename ILIKE '%{bk}%' "
+                 f"AND procurement_attr IN ('勞務類','財物類') AND ({kw})")
+        d = mcp.query_rows(where, COLS, MONTH_LIMIT, order_by="filename DESC")
+        cols, batch = d.get("columns", []), d.get("rows", [])
+        if len(batch) >= MONTH_LIMIT:
+            print(f"⚠️ 批次 {bk} 回傳達上限 {MONTH_LIMIT}，可能截斷", file=sys.stderr)
+        added = 0
+        for r in batch:
+            rec = dict(zip(cols, r))
+            if not pre_filter(rec.get("title") or ""):
+                dropped_bl += 1
+                continue
+            key = (rec.get("agency_id") or rec.get("agency"),
+                   rec.get("job_number"), rec.get("filename"))
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(map_row(rec))
+            added += 1
+        print(f"[批次 {bk}] raw {len(batch)} +{added} (total {len(rows)}, bl drop {dropped_bl})",
+              file=sys.stderr)
+        time.sleep(0.2)
+    return rows
 
 
 def fetch(since, until, token):
@@ -287,7 +354,7 @@ OUT_FIELDS = [
     "date", "unit_name", "unit_id", "type", "title", "category", "budget",
     "award_amount", "awarded_at", "companies", "job_number", "url",
     "notice_date", "award_way", "county", "county_code", "town_code",
-    "contact_person", "contact_phone", "losing_supplier",
+    "contact_person", "contact_phone", "losing_supplier", "filename",
 ]
 
 
@@ -302,8 +369,12 @@ def write_csv(rows, path):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--days", type=int, help="抓過去 N 天（與 --since 二選一）")
-    ap.add_argument("--since", help="起日 YYYY-MM-DD")
+    ap.add_argument("--latest-batches", type=int, default=None,
+                    help="抓最新 N 個發布批次（issue #22 方案 A；每日跑用這個，"
+                         "取代 --days 公告日窗）")
+    ap.add_argument("--days", type=int,
+                    help="抓過去 N 天公告日（backfill/相容用；新案偵測請改 --latest-batches）")
+    ap.add_argument("--since", help="起日 YYYY-MM-DD（backfill 用）")
     ap.add_argument("--until", help="迄日 YYYY-MM-DD（預設今天）")
     ap.add_argument("--out", default="data/weekly.csv")
     ap.add_argument("--token", default=os.environ.get("TWINKLE_API_KEY", ""))
@@ -312,13 +383,20 @@ def main():
     if not args.token:
         sys.exit("缺 token：設環境變數 TWINKLE_API_KEY 或傳 --token")
 
+    # 批次模式（每日跑預設路徑）：以發布批次為錨，不受官方 2 月延遲影響
+    if args.latest_batches:
+        rows = fetch_batches(args.token, args.latest_batches)
+        write_csv(rows, args.out)
+        return
+
+    # 公告日窗模式（backfill / 一次性回補；不適合每日新案偵測）
     until = args.until or datetime.now().strftime("%Y-%m-%d")
     if args.since:
         since = args.since
     elif args.days:
         since = (datetime.now() - timedelta(days=args.days)).strftime("%Y-%m-%d")
     else:
-        sys.exit("需指定 --since 或 --days")
+        sys.exit("需指定 --latest-batches、--since 或 --days")
 
     print(f"=== fetch pcc-tender {since} ~ {until} ===", file=sys.stderr)
     rows = fetch(since, until, args.token)

--- a/scripts/freshness.py
+++ b/scripts/freshness.py
@@ -79,9 +79,19 @@ def period_to_key(period) -> str:
     return f"{y:04d}{mo:02d}{half:02d}"
 
 
+def valid_batch_key(filename: str) -> str:
+    """取 filename 的批次日期段，且通過 batch_period 合法性驗證才回傳；否則 ''。
+
+    擋 `tender_20260403.xml`（half 03）/`tender_20261302.xml`（月 13）這種非法值
+    污染 max() 排序與游標推進（codex #3）。
+    """
+    bk = batch_key(filename)
+    return bk if batch_period(bk) is not None else ""
+
+
 def latest_batch(rows: list) -> str:
-    """rows 中最大的批次日期段（'YYYYMM0H'）；無有效批次回 ''。"""
-    keys = [bk for r in rows if (bk := batch_key(r.get("filename", "")))]
+    """rows 中最大的「合法」批次日期段（'YYYYMM0H'）；無有效批次回 ''。"""
+    keys = [bk for r in rows if (bk := valid_batch_key(r.get("filename", "")))]
     return max(keys) if keys else ""
 
 

--- a/scripts/freshness.py
+++ b/scripts/freshness.py
@@ -1,16 +1,25 @@
-"""資料新鮮度檢查 — 偵測上游資料源「斷糧」（issue #22）。
+"""資料新鮮度檢查 — 偵測上游資料源「斷糧」（issue #22，根因翻轉後重做）。
 
-問題背景：daily watcher 每天只 fetch 近 N 天（`--days 2`），上游 pcc-tender
-mirror 2026-04 底起停更後，每天抓回 0 筆 → `no_p0` → 靜默不發 Slack，
-「斷糧無人知」。本模組讓 watcher 主動偵測「資料源最新一筆日期距今太久」。
+問題背景（已實證翻轉）：官方政府電子採購網開放資料**天生有 ~2 個月發布延遲**
+（官方頁逐字：「每個月 5 號會產出 2 個月前的資料」），且資料以「半月批次檔」
+為單位發布，檔名如 `tender_20260402.xml` / `award_20260402.xml`（末 2 碼＝
+半月期別 01/02，非日）。
 
-判斷依據＝**master 資料集 `data/bids.csv` 的最大 `date`**（YYYYMMDD），
-而非本輪 weekly fetch：斷糧時 weekly 為空，但 master 的最大日期會「卡」在
-最後一次有料的日期，today 減它即「資料源停滯天數」。供料恢復後 master
-最大日期會隨 merge 前進，停滯天數自然歸零 → 不誤報。
+→ 因此「公告日距今」**量錯對象**：健康狀態下最新資料本就 ~60 天舊，用
+  「距今 14 天」會天天誤報。前一版（PR #23 初稿）的日期距今門檻已作廢。
 
-閾值 N：見 watcher.py FRESHNESS_DAYS 的取值理由（為何不是 brief 初估的 3–5）。
+判斷依據改成 **批次發布節奏**：
+- **批次識別**＝檔名 `filename` 的 8 碼日期段 `YYYYMM0H`（跨 tender_/award_
+  前綴統一用日期段比較，避免前綴字典序混比）。
+- **新鮮度**＝資料源「最新批次」是否落後「依官方節奏應有的最新批次」超過寬限。
+  官方每月約 5 號發布 2 月前整月（兩個半月批次）→ 預期最新批次 = 今天往前
+  2 個月（5 號前保守抓 3 個月）的下半月。落後超過 `grace_periods` 個半月期 →
+  判定真斷糧（mirror/ETL 沒跟上），非正常延遲。
+
+實證（2026-06-29）：TwinkleAI 最新批次 `tender_20260302`（3 月下半月）、官方已到
+`tender_20260402`（4 月下半月）→ 落後 2 個半月期 → 正當觸發告警（非誤報）。
 """
+import re
 from datetime import date, datetime
 
 try:
@@ -19,64 +28,102 @@ try:
 except Exception:  # 極端環境無 tzdata → 退回 naive（CI 已設 TZ）
     _TPE = None
 
+_BATCH_RE = re.compile(r"(\d{8})")
+
 
 def taipei_today() -> date:
     """以 Asia/Taipei 為準的今天（issue #22 #6）。
 
-    CI runner 多為 UTC，台北凌晨排程用 UTC date 會差 1 天，14 天門檻附近誤判。
-    一律用台北日界線判斷停滯天數。
+    CI runner 多為 UTC，台北凌晨排程用 UTC date 會差 1 天、在發布日 5 號邊界
+    附近誤判。一律用台北日界線。
     """
     if _TPE is not None:
         return datetime.now(_TPE).date()
     return date.today()
 
 
-def _parse_yyyymmdd(s: str):
-    """'20260504' -> date(2026,5,4)；非 8 碼數字回 None（容錯髒資料）。"""
-    s = (s or "").strip()
-    if len(s) != 8 or not s.isdigit():
-        return None
-    try:
-        return date(int(s[:4]), int(s[4:6]), int(s[6:8]))
-    except ValueError:
-        return None
+# ---------- 批次識別 ----------
+def batch_key(filename: str) -> str:
+    """從 filename 取 8 碼批次日期段 `YYYYMM0H`；取不到回 ''。
 
-
-def latest_data_date(rows: list, today: date = None) -> str:
-    """回傳 rows 中最大的 `date`（YYYYMMDD 字串）；無有效日期回 ''。
-
-    用字串比較找最大（YYYYMMDD 字典序＝時間序），再驗證可解析，
-    避免單一髒值（如 '99999999'）灌頂。
-
-    today 有給時忽略「未來日期」的髒行（issue #22 #4）：否則 `20991231`
-    這種壞資料會成為最大日期、age 變負、stale=False，把真斷糧遮蔽掉。
+    'tender_20260402.xml' / 'award_20260402.xml' 都 → '20260402'（跨前綴統一）。
+    用日期段比較才不會把 'award_...' 與 'tender_...' 的前綴字典序混進來。
     """
-    valid = []
-    for r in rows:
-        d = _parse_yyyymmdd(r.get("date", ""))
-        if d is None:
-            continue
-        if today is not None and d > today:
-            continue  # 未來日期＝髒資料，不採信
-        valid.append(r.get("date", "").strip())
-    return max(valid) if valid else ""
+    if not filename:
+        return ""
+    m = _BATCH_RE.search(str(filename))
+    return m.group(1) if m else ""
 
 
-def check_freshness(rows: list, threshold_days: int, today: date = None) -> dict:
-    """檢查資料新鮮度。
+def batch_period(bkey: str):
+    """'YYYYMM0H' → 連續半月期序號（int）；非法回 None。
 
-    回傳 dict：
-      - stale: bool        是否超過閾值（含「完全無有效日期」也算 stale）
-      - latest_date: str   master 最新日期 YYYYMMDD（無則 ''）
-      - age_days: int|None  距今天數（無有效日期則 None）
-      - threshold_days: int 用的閾值
+    序號＝year*24 + (month-1)*2 + (half-1)，相鄰半月差 1，可直接相減比節奏。
+    末 2 碼 half 僅接受 01/02（半月期別），其餘視為髒值。
+    """
+    if not bkey or len(bkey) != 8 or not bkey.isdigit():
+        return None
+    y, mo, half = int(bkey[:4]), int(bkey[4:6]), int(bkey[6:8])
+    if not (1 <= mo <= 12 and half in (1, 2)):
+        return None
+    return y * 24 + (mo - 1) * 2 + (half - 1)
+
+
+def period_to_key(period) -> str:
+    """半月期序號 → 'YYYYMM0H'（display 用）；None → ''。"""
+    if period is None:
+        return ""
+    y, rem = divmod(period, 24)
+    mo = rem // 2 + 1
+    half = rem % 2 + 1
+    return f"{y:04d}{mo:02d}{half:02d}"
+
+
+def latest_batch(rows: list) -> str:
+    """rows 中最大的批次日期段（'YYYYMM0H'）；無有效批次回 ''。"""
+    keys = [bk for r in rows if (bk := batch_key(r.get("filename", "")))]
+    return max(keys) if keys else ""
+
+
+def expected_latest_batch_period(today: date = None):
+    """依官方節奏，今天「應該」已有的最新批次期序號。
+
+    官方每月 5 號發布 2 個月前整月（含上/下兩個半月批次）→ 預期最新到
+    「今天 - 2 個月」的下半月（half=2）。今天 < 5 號時保守抓「-3 個月」，
+    避免在發布日前一兩天就誤報「沒出新批次」。
     """
     today = today or taipei_today()
-    latest = latest_data_date(rows, today=today)
-    if not latest:
-        # 完全沒有有效日期 → 視為斷糧（資料集空或全髒）
-        return {"stale": True, "latest_date": "", "age_days": None,
-                "threshold_days": threshold_days}
-    age = (today - _parse_yyyymmdd(latest)).days
-    return {"stale": age > threshold_days, "latest_date": latest,
-            "age_days": age, "threshold_days": threshold_days}
+    months_back = 2 if today.day >= 5 else 3
+    y, m = today.year, today.month - months_back
+    while m <= 0:
+        m += 12
+        y -= 1
+    return y * 24 + (m - 1) * 2 + (2 - 1)   # 該月下半月
+
+
+def check_batch_freshness(rows: list, today: date = None,
+                          grace_periods: int = 1) -> dict:
+    """以批次節奏判斷資料源是否斷糧。
+
+    回傳 dict：
+      - stale: bool          最新批次落後預期超過 grace_periods（或完全無批次）
+      - latest_batch: str    資料源最新批次 'YYYYMM0H'（無則 ''）
+      - expected_batch: str  依今天節奏應有的最新批次 'YYYYMM0H'
+      - lag_periods: int|None 落後幾個半月期（無批次則 None）
+      - grace_periods: int   容忍幾個半月期（發布時點 jitter）
+
+    grace_periods 預設 1：容忍落後 1 個半月期（官方某半月剛好還沒發的正常時點差），
+    落後 ≥2 個半月期才判真斷糧——避免把「正常半月延遲」誤報成斷糧。
+    """
+    today = today or taipei_today()
+    latest = latest_batch(rows)
+    lp = batch_period(latest)
+    exp = expected_latest_batch_period(today)
+    if lp is None:
+        # 完全沒有有效批次 → 視為斷糧（資料集空 / filename 全缺）
+        return {"stale": True, "latest_batch": "", "expected_batch": period_to_key(exp),
+                "lag_periods": None, "grace_periods": grace_periods}
+    lag = exp - lp
+    return {"stale": lag > grace_periods, "latest_batch": latest,
+            "expected_batch": period_to_key(exp), "lag_periods": lag,
+            "grace_periods": grace_periods}

--- a/scripts/freshness.py
+++ b/scripts/freshness.py
@@ -1,0 +1,55 @@
+"""資料新鮮度檢查 — 偵測上游資料源「斷糧」（issue #22）。
+
+問題背景：daily watcher 每天只 fetch 近 N 天（`--days 2`），上游 pcc-tender
+mirror 2026-04 底起停更後，每天抓回 0 筆 → `no_p0` → 靜默不發 Slack，
+「斷糧無人知」。本模組讓 watcher 主動偵測「資料源最新一筆日期距今太久」。
+
+判斷依據＝**master 資料集 `data/bids.csv` 的最大 `date`**（YYYYMMDD），
+而非本輪 weekly fetch：斷糧時 weekly 為空，但 master 的最大日期會「卡」在
+最後一次有料的日期，today 減它即「資料源停滯天數」。供料恢復後 master
+最大日期會隨 merge 前進，停滯天數自然歸零 → 不誤報。
+
+閾值 N：見 watcher.py FRESHNESS_DAYS 的取值理由（為何不是 brief 初估的 3–5）。
+"""
+from datetime import date
+
+
+def _parse_yyyymmdd(s: str):
+    """'20260504' -> date(2026,5,4)；非 8 碼數字回 None（容錯髒資料）。"""
+    s = (s or "").strip()
+    if len(s) != 8 or not s.isdigit():
+        return None
+    try:
+        return date(int(s[:4]), int(s[4:6]), int(s[6:8]))
+    except ValueError:
+        return None
+
+
+def latest_data_date(rows: list) -> str:
+    """回傳 rows 中最大的 `date`（YYYYMMDD 字串）；無有效日期回 ''。
+
+    用字串比較找最大（YYYYMMDD 字典序＝時間序），再驗證可解析，
+    避免單一髒值（如 '99999999'）灌頂。
+    """
+    valid = [r.get("date", "") for r in rows if _parse_yyyymmdd(r.get("date", ""))]
+    return max(valid) if valid else ""
+
+
+def check_freshness(rows: list, threshold_days: int, today: date = None) -> dict:
+    """檢查資料新鮮度。
+
+    回傳 dict：
+      - stale: bool        是否超過閾值（含「完全無有效日期」也算 stale）
+      - latest_date: str   master 最新日期 YYYYMMDD（無則 ''）
+      - age_days: int|None  距今天數（無有效日期則 None）
+      - threshold_days: int 用的閾值
+    """
+    today = today or date.today()
+    latest = latest_data_date(rows)
+    if not latest:
+        # 完全沒有有效日期 → 視為斷糧（資料集空或全髒）
+        return {"stale": True, "latest_date": "", "age_days": None,
+                "threshold_days": threshold_days}
+    age = (today - _parse_yyyymmdd(latest)).days
+    return {"stale": age > threshold_days, "latest_date": latest,
+            "age_days": age, "threshold_days": threshold_days}

--- a/scripts/freshness.py
+++ b/scripts/freshness.py
@@ -11,7 +11,24 @@ mirror 2026-04 底起停更後，每天抓回 0 筆 → `no_p0` → 靜默不發
 
 閾值 N：見 watcher.py FRESHNESS_DAYS 的取值理由（為何不是 brief 初估的 3–5）。
 """
-from datetime import date
+from datetime import date, datetime
+
+try:
+    from zoneinfo import ZoneInfo
+    _TPE = ZoneInfo("Asia/Taipei")
+except Exception:  # 極端環境無 tzdata → 退回 naive（CI 已設 TZ）
+    _TPE = None
+
+
+def taipei_today() -> date:
+    """以 Asia/Taipei 為準的今天（issue #22 #6）。
+
+    CI runner 多為 UTC，台北凌晨排程用 UTC date 會差 1 天，14 天門檻附近誤判。
+    一律用台北日界線判斷停滯天數。
+    """
+    if _TPE is not None:
+        return datetime.now(_TPE).date()
+    return date.today()
 
 
 def _parse_yyyymmdd(s: str):
@@ -25,13 +42,23 @@ def _parse_yyyymmdd(s: str):
         return None
 
 
-def latest_data_date(rows: list) -> str:
+def latest_data_date(rows: list, today: date = None) -> str:
     """回傳 rows 中最大的 `date`（YYYYMMDD 字串）；無有效日期回 ''。
 
     用字串比較找最大（YYYYMMDD 字典序＝時間序），再驗證可解析，
     避免單一髒值（如 '99999999'）灌頂。
+
+    today 有給時忽略「未來日期」的髒行（issue #22 #4）：否則 `20991231`
+    這種壞資料會成為最大日期、age 變負、stale=False，把真斷糧遮蔽掉。
     """
-    valid = [r.get("date", "") for r in rows if _parse_yyyymmdd(r.get("date", ""))]
+    valid = []
+    for r in rows:
+        d = _parse_yyyymmdd(r.get("date", ""))
+        if d is None:
+            continue
+        if today is not None and d > today:
+            continue  # 未來日期＝髒資料，不採信
+        valid.append(r.get("date", "").strip())
     return max(valid) if valid else ""
 
 
@@ -44,8 +71,8 @@ def check_freshness(rows: list, threshold_days: int, today: date = None) -> dict
       - age_days: int|None  距今天數（無有效日期則 None）
       - threshold_days: int 用的閾值
     """
-    today = today or date.today()
-    latest = latest_data_date(rows)
+    today = today or taipei_today()
+    latest = latest_data_date(rows, today=today)
     if not latest:
         # 完全沒有有效日期 → 視為斷糧（資料集空或全髒）
         return {"stale": True, "latest_date": "", "age_days": None,

--- a/scripts/slack_notify.py
+++ b/scripts/slack_notify.py
@@ -35,6 +35,54 @@ def build_payload(rows: list) -> dict:
     return {"text": text, "blocks": blocks}
 
 
+def build_freshness_payload(latest_date: str, age_days, threshold_days: int,
+                            source: str = "pcc-tender") -> dict:
+    """資料新鮮度告警 → Slack message payload（issue #22）。"""
+    if latest_date:
+        d = f"{latest_date[:4]}-{latest_date[4:6]}-{latest_date[6:8]}"
+        age_txt = f"{age_days} 天前" if age_days is not None else "未知"
+        detail = (f"資料源 *{source}* 最新一筆資料日期為 *{d}*（距今 {age_txt}），"
+                  f"已超過 {threshold_days} 天新鮮度門檻。")
+    else:
+        detail = (f"資料源 *{source}* 找不到任何有效日期資料（資料集為空或異常），"
+                  f"請立即檢查。")
+    blocks = [
+        {"type": "header",
+         "text": {"type": "plain_text", "text": "⚠️ 標案資料源斷糧告警"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": detail}},
+        {"type": "context", "elements": [{"type": "mrkdwn",
+         "text": "watcher 仍在運行，但上游可能停更——這不是正常的「今日無新標案」。"
+                 "請查 issue #22。"}]},
+    ]
+    return {"text": f"⚠️ 標案資料源斷糧告警：{source} {detail}", "blocks": blocks}
+
+
+def notify_freshness(latest_date: str, age_days, threshold_days: int,
+                     source: str = "pcc-tender", dry_run: bool = True,
+                     webhook: str = None) -> dict:
+    """推播資料新鮮度告警。語意/降級行為對齊 notify()。
+
+    dry_run=True（預設）→ 印 payload 不發送。
+    dry_run=False 但無 webhook → 不發送、reason='no_webhook'（安全降級）。
+    """
+    payload = build_freshness_payload(latest_date, age_days, threshold_days, source)
+    webhook = webhook or os.environ.get("SLACK_WEBHOOK_URL", "")
+
+    if dry_run:
+        print("[slack dry-run] freshness payload:", file=sys.stderr)
+        print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr)
+        return {"sent": False, "dry_run": True, "reason": "dry_run"}
+
+    if not webhook:
+        print("[slack] 無 SLACK_WEBHOOK_URL → 不推送新鮮度告警（安全降級）",
+              file=sys.stderr)
+        return {"sent": False, "dry_run": False, "reason": "no_webhook"}
+
+    resp = requests.post(webhook, json=payload, timeout=30)
+    resp.raise_for_status()
+    return {"sent": True, "dry_run": False, "reason": "ok"}
+
+
 def notify(rows: list, dry_run: bool = True, webhook: str = None) -> dict:
     """推播 P0 列。回傳 {sent, dry_run, count, reason}。
 

--- a/scripts/slack_notify.py
+++ b/scripts/slack_notify.py
@@ -66,7 +66,10 @@ def notify_freshness(latest_date: str, age_days, threshold_days: int,
     dry_run=False 但無 webhook → 不發送、reason='no_webhook'（安全降級）。
     """
     payload = build_freshness_payload(latest_date, age_days, threshold_days, source)
-    webhook = webhook or os.environ.get("SLACK_WEBHOOK_URL", "")
+    # #7：只在 webhook 為 None 才 fallback 到 env；明確傳入的空字串＝呼叫端
+    # 要求「不要 webhook」（測試在有 SLACK_WEBHOOK_URL 的環境也不會誤送真訊息）。
+    if webhook is None:
+        webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
 
     if dry_run:
         print("[slack dry-run] freshness payload:", file=sys.stderr)
@@ -90,7 +93,9 @@ def notify(rows: list, dry_run: bool = True, webhook: str = None) -> dict:
     dry_run=False 但無 webhook → 不發送、reason='no_webhook'（不報錯，安全降級）。
     """
     payload = build_payload(rows)
-    webhook = webhook or os.environ.get("SLACK_WEBHOOK_URL", "")
+    # #7：只在 webhook 為 None 才 fallback 到 env（空字串＝明確不送，見 notify_freshness）。
+    if webhook is None:
+        webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
 
     if dry_run:
         print("[slack dry-run] payload:", file=sys.stderr)

--- a/scripts/slack_notify.py
+++ b/scripts/slack_notify.py
@@ -35,37 +35,46 @@ def build_payload(rows: list) -> dict:
     return {"text": text, "blocks": blocks}
 
 
-def build_freshness_payload(latest_date: str, age_days, threshold_days: int,
+def _fmt_batch(bkey: str) -> str:
+    """'20260302' → '2026-03 下半月'（半月期別人話化）；空 → '無'。"""
+    if not bkey or len(bkey) != 8:
+        return "無"
+    half = "下半月" if bkey[6:8] == "02" else "上半月"
+    return f"{bkey[:4]}-{bkey[4:6]} {half}"
+
+
+def build_freshness_payload(latest_batch: str, expected_batch: str, lag_periods,
                             source: str = "pcc-tender") -> dict:
-    """資料新鮮度告警 → Slack message payload（issue #22）。"""
-    if latest_date:
-        d = f"{latest_date[:4]}-{latest_date[4:6]}-{latest_date[6:8]}"
-        age_txt = f"{age_days} 天前" if age_days is not None else "未知"
-        detail = (f"資料源 *{source}* 最新一筆資料日期為 *{d}*（距今 {age_txt}），"
-                  f"已超過 {threshold_days} 天新鮮度門檻。")
+    """資料新鮮度告警 → Slack message payload（issue #22，批次節奏版）。"""
+    if latest_batch:
+        lag_txt = f"{lag_periods} 個半月期" if lag_periods is not None else "未知"
+        detail = (f"資料源 *{source}* 最新批次為 *{_fmt_batch(latest_batch)}*"
+                  f"（{latest_batch}），但依官方發布節奏應已有 "
+                  f"*{_fmt_batch(expected_batch)}*（{expected_batch}）——"
+                  f"落後 *{lag_txt}*，研判上游 mirror/ETL 沒跟上、非正常 2 月延遲。")
     else:
-        detail = (f"資料源 *{source}* 找不到任何有效日期資料（資料集為空或異常），"
+        detail = (f"資料源 *{source}* 找不到任何有效批次（資料集為空或 filename 全缺），"
                   f"請立即檢查。")
     blocks = [
         {"type": "header",
          "text": {"type": "plain_text", "text": "⚠️ 標案資料源斷糧告警"}},
         {"type": "section", "text": {"type": "mrkdwn", "text": detail}},
         {"type": "context", "elements": [{"type": "mrkdwn",
-         "text": "watcher 仍在運行，但上游可能停更——這不是正常的「今日無新標案」。"
-                 "請查 issue #22。"}]},
+         "text": "watcher 仍在運行，但上游批次沒如期更新——這不是正常的「今日無新標案」"
+                 "也不是官方固有的 2 月延遲。請查 issue #22。"}]},
     ]
     return {"text": f"⚠️ 標案資料源斷糧告警：{source} {detail}", "blocks": blocks}
 
 
-def notify_freshness(latest_date: str, age_days, threshold_days: int,
+def notify_freshness(latest_batch: str, expected_batch: str, lag_periods,
                      source: str = "pcc-tender", dry_run: bool = True,
                      webhook: str = None) -> dict:
-    """推播資料新鮮度告警。語意/降級行為對齊 notify()。
+    """推播資料新鮮度告警（批次節奏版）。語意/降級行為對齊 notify()。
 
     dry_run=True（預設）→ 印 payload 不發送。
     dry_run=False 但無 webhook → 不發送、reason='no_webhook'（安全降級）。
     """
-    payload = build_freshness_payload(latest_date, age_days, threshold_days, source)
+    payload = build_freshness_payload(latest_batch, expected_batch, lag_periods, source)
     # #7：只在 webhook 為 None 才 fallback 到 env；明確傳入的空字串＝呼叫端
     # 要求「不要 webhook」（測試在有 SLACK_WEBHOOK_URL 的環境也不會誤送真訊息）。
     if webhook is None:

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -113,13 +113,19 @@ def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
         return fr
 
     if should:
+        # 先寫 alert 檔留痕（不論最終有無推到 Slack，都要有可追的紀錄）。
         write_alert("data_freshness", {
             "source": "pcc-tender", "latest_date": fr["latest_date"],
             "age_days": fr["age_days"], "threshold_days": freshness_days,
             "hint": "上游資料源停滯/斷糧；watcher 本身正常。見 issue #22。",
         })
-        notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
-                         dry_run=dry_run)
+        res = notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
+                               dry_run=dry_run)
+        # ⚠️ 節流只在「真的送達 Slack」才啟動（codex 複審）：no_webhook / 送失敗
+        #    若也消耗 3 天 realert 窗，告警會被靜默壓掉 → 回到「靜默斷糧」。
+        #    沒送達 → 不標 alerted、不寫節流 state，下輪會重試推送。
+        if not res.get("sent"):
+            return fr
         state["freshness_alert"] = {"latest_date": fr["latest_date"],
                                     "last_alert_date": today.isoformat()}
         fr["alerted"] = True

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -20,7 +20,12 @@ from datetime import date, datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from freshness import check_freshness, taipei_today  # noqa: E402
+from freshness import (  # noqa: E402
+    batch_key,
+    check_batch_freshness,
+    latest_batch,
+    taipei_today,
+)
 from p0_rules import is_p0  # noqa: E402
 from slack_notify import notify, notify_freshness  # noqa: E402
 from watcher_diff import (  # noqa: E402
@@ -34,19 +39,18 @@ from watcher_diff import (  # noqa: E402
 PUSH_CAP = 20          # 單輪推播上限，超過 → 降級 alert 不推
 ALERT_DIR = "data/alerts"
 
-# 資料新鮮度門檻（issue #22）：master 最新 date 距今 > 此天數 → 判定上游斷糧、告警。
+# 資料新鮮度寬限（issue #22，批次節奏版）：資料源最新「批次」落後「依官方節奏
+# 應有的最新批次」超過此半月期數 → 判定上游斷糧、告警。
 #
-# 為何是 14 而非 brief 初估的 3–5：pcc-tender 是「官方半月公開資料」，正常供料下
-# 最新日期本就會隨發布週期落後。實測健康期（2026 Jan–Apr）master 資料：
-#   - 有料日多為每日/每 1–3 天一筆，
-#   - 但農曆年等假期出現過最大 10 天的資料空窗（2/13→2/23），
-#   - 疊加半月一次的發布節奏，下次發布前最新日期可正常落後到 ~16 天。
-# 門檻設 3–5 會在每個假期/發布前空窗誤報 → 違反「正常供料不誤報」鐵則，
-# 狼來了喊久就被無視＝退回靜默失敗。14 天＝大於實測最壞正常空窗(10)+裕度，
-# 仍能在再次斷糧後約兩週內告警；當前已斷糧 56 天 → 立即觸發。可用 --freshness-days 調。
-FRESHNESS_DAYS = 14
+# 為何用批次而非「公告日距今」：pcc 官方天生有 ~2 個月發布延遲（每月 5 號發 2 月
+# 前資料）、且以半月批次檔（filename=YYYYMM0H）為單位。健康狀態下最新資料本就
+# ~60 天舊，量「公告日距今」會天天誤報。改量「最新批次有沒有如期出現」。
+# grace=1：容忍落後 1 個半月期（官方某半月剛好還沒發的正常時點差），落後 ≥2 期
+# 才判真斷糧。實證 2026-06-29：TwinkleAI 卡在 20260302、官方已 20260402 → 落後 2
+# 期 → 正當觸發。可用 --freshness-grace 調。
+FRESHNESS_GRACE_PERIODS = 1
 # 斷糧持續期間的重提間隔（天）：避免長期斷糧每天重複轟炸 Slack。
-# 首次偵測立即推；之後同一停滯狀態每 N 天重提一次（最新日期變動也會重提）。
+# 首次偵測立即推；之後同一停滯狀態（最新批次不變）每 N 天重提一次。
 FRESHNESS_REALERT_DAYS = 3
 
 
@@ -68,13 +72,13 @@ def read_rows(csv_path: str) -> list:
 
 
 def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
-                         freshness_days: int, realert_days: int,
+                         grace_periods: int, realert_days: int,
                          today: date = None) -> dict:
-    """偵測 master 資料源是否斷糧；stale 時推 Slack 告警（含重提節流）。
+    """偵測 master 資料源是否斷糧（批次節奏版）；stale 時推 Slack（含重提節流）。
 
-    回傳 freshness dict（check_freshness 結果再加 alerted / would_alert: bool）。
-    節流：同一停滯狀態（latest_date 不變）每 realert_days 天最多重提一次；
-    latest_date 變動（資料前進或回退）視為新狀態，立即重提。
+    回傳 freshness dict（check_batch_freshness 結果再加 alerted / would_alert）。
+    節流：同一停滯狀態（latest_batch 不變）每 realert_days 天最多重提一次；
+    latest_batch 變動（出新批次或回退）視為新狀態，立即重提。
 
     dry_run=True（issue #22 #1）：只回報「若真推會不會 alert」（would_alert），
     **不寫 alert 檔、不更新節流狀態**。否則手動 dry-run 會消耗 realert_days
@@ -82,21 +86,21 @@ def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
     """
     today = today or taipei_today()
     rows = read_rows(master_csv)
-    fr = check_freshness(rows, freshness_days, today=today)
+    fr = check_batch_freshness(rows, today=today, grace_periods=grace_periods)
     fr["alerted"] = False
     fr["would_alert"] = False
     if not fr["stale"]:
-        # 恢復供料 → 清掉節流紀錄，下次再斷糧能立即重提。
+        # 批次如期更新 → 清掉節流紀錄，下次再斷糧能立即重提。
         # dry-run 不改 state（#1）：只在真跑時清。
         if not dry_run:
             state.pop("freshness_alert", None)
         return fr
 
     prev = state.get("freshness_alert") or {}
-    prev_latest = prev.get("latest_date")
+    prev_latest = prev.get("latest_batch")
     prev_date = prev.get("last_alert_date")
     should = True
-    if prev_latest == fr["latest_date"] and prev_date:
+    if prev_latest == fr["latest_batch"] and prev_date:
         # 壞掉的節流紀錄（空字串/舊格式/merge 殘留）→ 視為「無有效節流」續推（#2）
         try:
             prev_d = datetime.strptime(prev_date, "%Y-%m-%d").date()
@@ -108,41 +112,70 @@ def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
     if dry_run:
         # dry-run：印 payload 供 smoke，但不落 alert 檔、不動節流狀態（#1）
         if should:
-            notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
-                             dry_run=True)
+            notify_freshness(fr["latest_batch"], fr["expected_batch"],
+                             fr["lag_periods"], dry_run=True)
         return fr
 
     if should:
         # 先寫 alert 檔留痕（不論最終有無推到 Slack，都要有可追的紀錄）。
         write_alert("data_freshness", {
-            "source": "pcc-tender", "latest_date": fr["latest_date"],
-            "age_days": fr["age_days"], "threshold_days": freshness_days,
-            "hint": "上游資料源停滯/斷糧；watcher 本身正常。見 issue #22。",
+            "source": "pcc-tender", "latest_batch": fr["latest_batch"],
+            "expected_batch": fr["expected_batch"], "lag_periods": fr["lag_periods"],
+            "hint": "上游批次沒如期更新（非官方固有 2 月延遲）；watcher 本身正常。見 issue #22。",
         })
-        res = notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
-                               dry_run=dry_run)
+        res = notify_freshness(fr["latest_batch"], fr["expected_batch"],
+                               fr["lag_periods"], dry_run=dry_run)
         # ⚠️ 節流只在「真的送達 Slack」才啟動（codex 複審）：no_webhook / 送失敗
         #    若也消耗 3 天 realert 窗，告警會被靜默壓掉 → 回到「靜默斷糧」。
         #    沒送達 → 不標 alerted、不寫節流 state，下輪會重試推送。
         if not res.get("sent"):
             return fr
-        state["freshness_alert"] = {"latest_date": fr["latest_date"],
+        state["freshness_alert"] = {"latest_batch": fr["latest_batch"],
                                     "last_alert_date": today.isoformat()}
         fr["alerted"] = True
     return fr
 
 
+def find_new_by_batch(rows: list, state: dict):
+    """新案偵測改以「批次」為錨（issue #22 方案 A）。
+
+    資料源永遠落後 ~2 個月、`date` 還可能是未來/截止日 → 不能用「公告日最近 N 天」
+    當新案窗。改追「已處理過的最新批次 `last_batch`」：只把 **比 last_batch 新的
+    批次** 的案子當新案，再經既有 seen_keys 去重（同批次重抓不重推）。
+
+    回傳 (new_rows, mode, cand)：
+    - mode='fallback'：rows 完全沒有批次訊號（filename 全缺，非 pcc/舊資料）→ 退回
+      既有 seen_keys 水位法，向後相容（不讓無 filename 的資料整批靜默）。
+    - mode='baseline'：冷啟動（state 從未記過 last_batch）→ 只設基線、不回補整個歷史
+      backlog（否則首輪一次湧入數千案、必觸成本封頂），本輪不視為新案。
+    - mode='batch'：正常批次偵測，cand＝比 last_batch 新的批次的列。
+    """
+    cur = latest_batch(rows)
+    if not cur:
+        # 無任何批次訊號 → 退回水位法（drill abort / 非 pcc 測試資料仍可運作）
+        return find_new(rows, state), "fallback", rows
+    if "last_batch" not in state:
+        return [], "baseline", []
+    last_b = state.get("last_batch", "") or ""
+    cand = [r for r in rows
+            if (bk := batch_key(r.get("filename", ""))) and bk > last_b]
+    return find_new(cand, state), "batch", cand
+
+
 def run(weekly_csv: str, state_path: str, dry_run: bool = True,
         push_cap: int = PUSH_CAP, master_csv: str = None,
-        freshness_days: int = FRESHNESS_DAYS,
+        grace_periods: int = FRESHNESS_GRACE_PERIODS,
         realert_days: int = FRESHNESS_REALERT_DAYS, today: date = None) -> dict:
     """跑一輪 watcher。回傳結果 dict（含 status: ok|capped）。
 
     時間封頂改由 CI step `timeout-minutes` 硬 kill（見 daily-watcher.yml），
     本檔不做軟檢查（純記憶體操作跑不到 300s，軟檢查是擺設；ADR D4）。
 
-    master_csv 有給時，額外做「資料新鮮度檢查」（issue #22）：master 最新日期
-    距今 > freshness_days → 推 Slack 斷糧告警。master_csv=None 時跳過（不影響
+    新案偵測（issue #22 方案 A）：以批次（filename）為錨，只推「比已處理批次新的
+    批次」的案子，廢除舊「公告日最近 2 天」窗。
+
+    master_csv 有給時，額外做「資料新鮮度檢查」（issue #22）：資料源最新批次落後
+    官方節奏超過 grace_periods → 推 Slack 斷糧告警。master_csv=None 時跳過（不影響
     既有 P0 推播流程與舊測試）。
     """
     state = load_state(state_path)
@@ -154,42 +187,63 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     if master_csv:
         try:
             freshness = check_data_freshness(master_csv, state, dry_run,
-                                             freshness_days, realert_days, today=today)
+                                             grace_periods, realert_days, today=today)
         except Exception as e:  # noqa: BLE001 — 任何 master 端錯誤都不得中斷 P0
             print(f"::warning::[freshness] 新鮮度檢查失敗、已跳過（不影響 P0）：{e}",
                   file=sys.stderr)
             freshness = {"error": str(e), "stale": None, "alerted": False}
 
     rows = read_rows(weekly_csv)
+    cur_batch = latest_batch(rows)
 
-    # 1. diff：水位找新出現
-    new_rows = find_new(rows, state)
+    # 1. 新案偵測：批次錨（+ seen_keys 去重）；無批次訊號退回水位法
+    new_rows, mode, cand = find_new_by_batch(rows, state)
     # 2. P0 布林過濾
     p0_rows = [r for r in new_rows if is_p0(r)]
 
     result = {"fetched": len(rows), "new": len(new_rows),
               "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None,
-              "freshness": freshness}
+              "freshness": freshness, "batch": cur_batch,
+              "baseline": mode == "baseline", "mode": mode}
 
-    # 3. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
-    #    ⚠️ 0 漏報鐵則（issue #14 §4）：capped 時水位仍前進，被擋的 P0 下輪
-    #    不會再被 find_new 看到。因此 alert 必須完整記錄被擋清單，讓人能手動補救。
+    def _advance(note):
+        """收尾：推進批次游標 + 水位 + run-log + 存檔（各分支共用）。
+
+        batch 模式只把本批候選列入水位（不灌入舊批次列汙染）；fallback 退回水位
+        法時則維持既有「整批列入」行為。游標 last_batch 隨已見最大批次前進。
+        """
+        commit_watermark(cand if mode == "batch" else rows, state)
+        if cur_batch:
+            prev = state.get("last_batch", "") or ""
+            state["last_batch"] = max(cur_batch, prev)
+        append_runlog(state, fetched=len(rows), new=len(new_rows),
+                      pushed=result["pushed"], note=note)
+        save_state(state, state_path)
+
+    # 3. 冷啟動基線：只設游標不推（不 commit 水位，避免毒化下一批偵測）
+    if mode == "baseline":
+        if cur_batch:
+            state["last_batch"] = cur_batch
+        append_runlog(state, fetched=len(rows), new=0, pushed=0,
+                      note=f"baseline batch={cur_batch or '-'}")
+        save_state(state, state_path)
+        return result
+
+    # 4. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
+    #    ⚠️ 0 漏報鐵則（issue #14 §4）：capped 時游標仍前進，被擋的 P0 下輪
+    #    不會再被偵測到。因此 alert 必須完整記錄被擋清單，讓人能手動補救。
     if len(p0_rows) > push_cap:
         blocked = [{"title": r.get("title", ""),
                     "unit_name": r.get("unit_name", ""),
                     "job_number": r.get("job_number", "")}
                    for r in p0_rows]
         alert = write_alert("push_cap_exceeded", {
-            "p0_count": len(p0_rows), "cap": push_cap,
-            "hint": "可能規則過鬆或水位回退/資料異常，停下檢查，未推 Slack",
-            "blocked_p0": blocked,  # 被擋的完整清單，供人工補救（水位已前進）
+            "p0_count": len(p0_rows), "cap": push_cap, "batch": cur_batch,
+            "hint": "可能規則過鬆或游標回退/資料異常，停下檢查，未推 Slack",
+            "blocked_p0": blocked,  # 被擋的完整清單，供人工補救（游標已前進）
         })
         result.update(status="capped", alert=alert)
-        # 水位仍前進（避免下輪重複爆量），但不推播
-        commit_watermark(rows, state)
-        append_runlog(state, fetched=len(rows), new=len(new_rows),
-                      pushed=0, note=f"CAPPED p0={len(p0_rows)}>{push_cap}")
-        save_state(state, state_path)
+        _advance(f"CAPPED p0={len(p0_rows)}>{push_cap} batch={cur_batch}")
         return result
 
     # 5. 推播（dry-run 預設）
@@ -198,12 +252,8 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     result["pushed"] = len(p0_rows) if (push_res.get("sent") or dry_run) else 0
     result["push_reason"] = push_res.get("reason")
 
-    # 6. 更新水位 + run-log
-    commit_watermark(rows, state)
-    append_runlog(state, fetched=len(rows), new=len(new_rows),
-                  pushed=result["pushed"],
-                  note=f"dry_run={dry_run} p0={len(p0_rows)}")
-    save_state(state, state_path)
+    # 6. 推進游標 + 水位 + run-log
+    _advance(f"dry_run={dry_run} p0={len(p0_rows)} batch={cur_batch}")
     return result
 
 
@@ -216,13 +266,13 @@ def main():
     ap.add_argument("--push-cap", type=int, default=PUSH_CAP)
     ap.add_argument("--master", default=None,
                     help="master 資料集 CSV；給了才做資料新鮮度檢查（issue #22）")
-    ap.add_argument("--freshness-days", type=int, default=FRESHNESS_DAYS,
-                    help=f"資料最新日期距今超過此天數判定斷糧（預設 {FRESHNESS_DAYS}）")
+    ap.add_argument("--freshness-grace", type=int, default=FRESHNESS_GRACE_PERIODS,
+                    help=f"最新批次落後預期超過此半月期數判定斷糧（預設 {FRESHNESS_GRACE_PERIODS}）")
     args = ap.parse_args()
 
     res = run(args.weekly, args.state, dry_run=not args.push,
               push_cap=args.push_cap, master_csv=args.master,
-              freshness_days=args.freshness_days)
+              grace_periods=args.freshness_grace)
     print(json.dumps(res, ensure_ascii=False), file=sys.stderr)
     # capped 用非零退出碼讓 CI 標記降級（但不算 fetch 失敗）
     if res["status"] == "capped":

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -21,10 +21,11 @@ from datetime import date, datetime
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from freshness import (  # noqa: E402
-    batch_key,
+    batch_period,
     check_batch_freshness,
     latest_batch,
     taipei_today,
+    valid_batch_key,
 )
 from p0_rules import is_p0  # noqa: E402
 from slack_notify import notify, notify_freshness  # noqa: E402
@@ -144,22 +145,35 @@ def find_new_by_batch(rows: list, state: dict):
     批次** 的案子當新案，再經既有 seen_keys 去重（同批次重抓不重推）。
 
     回傳 (new_rows, mode, cand)：
-    - mode='fallback'：rows 完全沒有批次訊號（filename 全缺，非 pcc/舊資料）→ 退回
-      既有 seen_keys 水位法，向後相容（不讓無 filename 的資料整批靜默）。
-    - mode='baseline'：冷啟動（state 從未記過 last_batch）→ 只設基線、不回補整個歷史
-      backlog（否則首輪一次湧入數千案、必觸成本封頂），本輪不視為新案。
-    - mode='batch'：正常批次偵測，cand＝比 last_batch 新的批次的列。
+    - mode='fallback'：rows 完全沒有合法批次訊號（filename 全缺/全髒，非 pcc/舊資料）
+      → 退回既有 seen_keys 水位法，向後相容（不讓無 filename 的資料整批靜默）。
+    - mode='baseline'：冷啟動（state 從未記 last_batch）或 last_batch 壞掉（非法值，
+      codex #5）→ 只設基線、不回補整個歷史 backlog，本輪不視為新案。
+    - mode='batch'：正常批次偵測。cand＝比 last_batch 新的「合法批次」列；同份資料中
+      無/非法 filename 的列（codex #4）另走 seen_keys 水位法，不被靜默忽略。
     """
-    cur = latest_batch(rows)
+    cur = latest_batch(rows)   # 只看合法批次（#3）
     if not cur:
-        # 無任何批次訊號 → 退回水位法（drill abort / 非 pcc 測試資料仍可運作）
+        # 無任何合法批次訊號 → 退回水位法（drill abort / 非 pcc 測試資料仍可運作）
         return find_new(rows, state), "fallback", rows
     if "last_batch" not in state:
         return [], "baseline", []
     last_b = state.get("last_batch", "") or ""
+    # #5：壞掉的游標（舊格式/手改/merge 污染成非法值）→ 警告 + 重設基線，
+    #     不靠它判斷（否則合法新批次全判不出 → 靜默漏報）。
+    if batch_period(last_b) is None:
+        print(f"::warning::[batch] last_batch={last_b!r} 非法，重設基線（不推本輪）",
+              file=sys.stderr)
+        return [], "baseline", []
+    # 合法批次 > 游標 = 新批次候選
     cand = [r for r in rows
-            if (bk := batch_key(r.get("filename", ""))) and bk > last_b]
-    return find_new(cand, state), "batch", cand
+            if (bk := valid_batch_key(r.get("filename", ""))) and bk > last_b]
+    # #4：同份資料中無/非法 filename 的列 → 另走水位法，不靜默丟掉
+    no_batch = [r for r in rows if not valid_batch_key(r.get("filename", ""))]
+    new = find_new(cand, state)
+    if no_batch:
+        new = new + find_new(no_batch, state)
+    return new, "batch", cand
 
 
 def run(weekly_csv: str, state_path: str, dry_run: bool = True,
@@ -201,21 +215,44 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     # 2. P0 布林過濾
     p0_rows = [r for r in new_rows if is_p0(r)]
 
+    # 批次缺口偵測（#2）：fetch 只抓最新 N 批，若 watcher 停跑/mirror 一次補多批，
+    # cur_batch 與游標的期距 > 本輪實際抓到的不同批次數 → 中間批次沒被抓到。
+    fetched_batches = len({valid_batch_key(r.get("filename", "")) for r in rows
+                           if valid_batch_key(r.get("filename", ""))})
+    gap = False
+    if mode == "batch" and cur_batch:
+        last_b = state.get("last_batch", "") or ""
+        span = batch_period(cur_batch) - batch_period(last_b)
+        gap = span > fetched_batches   # 期距比抓到的批次數還大 → 有沒抓到的中間批次
+
     result = {"fetched": len(rows), "new": len(new_rows),
               "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None,
               "freshness": freshness, "batch": cur_batch,
-              "baseline": mode == "baseline", "mode": mode}
+              "baseline": mode == "baseline", "mode": mode, "gap": gap}
 
-    def _advance(note):
-        """收尾：推進批次游標 + 水位 + run-log + 存檔（各分支共用）。
+    # ── dry-run 一律唯讀（#1）：算完就回，不寫 alert / 不存 state ──
+    #    manual dispatch（push=false）會把 state commit 回 repo，若 dry-run 推進
+    #    游標，新批次被標已處理但 Slack 沒推 → 下次 schedule 同批不再推（漏報）。
+    if dry_run:
+        if mode != "baseline" and len(p0_rows) > push_cap:
+            result.update(status="capped")
+        else:
+            result["pushed"] = len(p0_rows)      # would-push（未真送）
+        result["push_reason"] = "dry_run"
+        return result
 
-        batch 模式只把本批候選列入水位（不灌入舊批次列汙染）；fallback 退回水位
-        法時則維持既有「整批列入」行為。游標 last_batch 隨已見最大批次前進。
+    # ── 以下為真跑（push 模式）：才有 disk 副作用 ──
+    def _persist(note, advance):
+        """run-log + 存檔；advance=True 才推進游標 + 把本輪列入水位。
+
+        advance=False（送失敗）→ 不 commit 水位也不推游標，下輪會重抓重試；
+        仍 save_state 以保住 freshness 節流 / run-log（送失敗不該連帶丟掉）。
         """
-        commit_watermark(cand if mode == "batch" else rows, state)
-        if cur_batch:
-            prev = state.get("last_batch", "") or ""
-            state["last_batch"] = max(cur_batch, prev)
+        if advance:
+            commit_watermark(cand if mode == "batch" else rows, state)
+            if cur_batch:
+                prev = state.get("last_batch", "") or ""
+                state["last_batch"] = max(cur_batch, prev)
         append_runlog(state, fetched=len(rows), new=len(new_rows),
                       pushed=result["pushed"], note=note)
         save_state(state, state_path)
@@ -228,6 +265,16 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
                       note=f"baseline batch={cur_batch or '-'}")
         save_state(state, state_path)
         return result
+
+    # 缺口留痕（#2）：仍推已抓批次，但警示人工 backfill 沒抓到的中間批次
+    if gap:
+        write_alert("batch_gap", {
+            "last_batch": state.get("last_batch", ""), "cur_batch": cur_batch,
+            "fetched_batches": fetched_batches,
+            "hint": "fetch 只抓最新批次、中間有批次沒抓到（watcher 久停/mirror 補多批）。"
+                    "請用 fetch_pcc.py --since 回補後再跑，免漏標案。見 issue #22。",
+        })
+        result["alert"] = "batch_gap"
 
     # 4. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
     #    ⚠️ 0 漏報鐵則（issue #14 §4）：capped 時游標仍前進，被擋的 P0 下輪
@@ -243,17 +290,22 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
             "blocked_p0": blocked,  # 被擋的完整清單，供人工補救（游標已前進）
         })
         result.update(status="capped", alert=alert)
-        _advance(f"CAPPED p0={len(p0_rows)}>{push_cap} batch={cur_batch}")
+        _persist(f"CAPPED p0={len(p0_rows)}>{push_cap} batch={cur_batch}",
+                 advance=True)
         return result
 
-    # 5. 推播（dry-run 預設）
-    push_res = notify(p0_rows, dry_run=dry_run) if p0_rows else \
+    # 5. 推播
+    push_res = notify(p0_rows, dry_run=False) if p0_rows else \
         {"sent": False, "count": 0, "reason": "no_p0"}
-    result["pushed"] = len(p0_rows) if (push_res.get("sent") or dry_run) else 0
+    delivered = bool(push_res.get("sent")) or push_res.get("reason") == "no_p0"
+    result["pushed"] = len(p0_rows) if push_res.get("sent") else 0
     result["push_reason"] = push_res.get("reason")
 
-    # 6. 推進游標 + 水位 + run-log
-    _advance(f"dry_run={dry_run} p0={len(p0_rows)} batch={cur_batch}")
+    # 6. 推進游標 + 水位 + run-log。
+    #    ⚠️ 只在「真的送達」或「本來就沒 P0 可送」才推進（#1）：送失敗（webhook
+    #    錯/降級）不推進、不列入水位，下輪重抓該批重試，免新案被標已處理卻沒送出。
+    _persist(f"push p0={len(p0_rows)} sent={push_res.get('sent')} batch={cur_batch}",
+             advance=delivered)
     return result
 
 

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -20,7 +20,7 @@ from datetime import date, datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from freshness import check_freshness  # noqa: E402
+from freshness import check_freshness, taipei_today  # noqa: E402
 from p0_rules import is_p0  # noqa: E402
 from slack_notify import notify, notify_freshness  # noqa: E402
 from watcher_diff import (  # noqa: E402
@@ -72,17 +72,24 @@ def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
                          today: date = None) -> dict:
     """偵測 master 資料源是否斷糧；stale 時推 Slack 告警（含重提節流）。
 
-    回傳 freshness dict（check_freshness 結果再加 alerted: bool）。
+    回傳 freshness dict（check_freshness 結果再加 alerted / would_alert: bool）。
     節流：同一停滯狀態（latest_date 不變）每 realert_days 天最多重提一次；
     latest_date 變動（資料前進或回退）視為新狀態，立即重提。
+
+    dry_run=True（issue #22 #1）：只回報「若真推會不會 alert」（would_alert），
+    **不寫 alert 檔、不更新節流狀態**。否則手動 dry-run 會消耗 realert_days
+    節流，把隨後的真推壓掉。
     """
-    today = today or date.today()
+    today = today or taipei_today()
     rows = read_rows(master_csv)
     fr = check_freshness(rows, freshness_days, today=today)
     fr["alerted"] = False
+    fr["would_alert"] = False
     if not fr["stale"]:
-        # 恢復供料 → 清掉節流紀錄，下次再斷糧能立即重提
-        state.pop("freshness_alert", None)
+        # 恢復供料 → 清掉節流紀錄，下次再斷糧能立即重提。
+        # dry-run 不改 state（#1）：只在真跑時清。
+        if not dry_run:
+            state.pop("freshness_alert", None)
         return fr
 
     prev = state.get("freshness_alert") or {}
@@ -90,8 +97,20 @@ def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
     prev_date = prev.get("last_alert_date")
     should = True
     if prev_latest == fr["latest_date"] and prev_date:
-        prev_d = datetime.strptime(prev_date, "%Y-%m-%d").date()
-        should = (today - prev_d).days >= realert_days
+        # 壞掉的節流紀錄（空字串/舊格式/merge 殘留）→ 視為「無有效節流」續推（#2）
+        try:
+            prev_d = datetime.strptime(prev_date, "%Y-%m-%d").date()
+            should = (today - prev_d).days >= realert_days
+        except (ValueError, TypeError):
+            should = True
+
+    fr["would_alert"] = should
+    if dry_run:
+        # dry-run：印 payload 供 smoke，但不落 alert 檔、不動節流狀態（#1）
+        if should:
+            notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
+                             dry_run=True)
+        return fr
 
     if should:
         write_alert("data_freshness", {
@@ -123,10 +142,17 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     state = load_state(state_path)
 
     # 0. 資料新鮮度檢查（issue #22）：與 P0 流程獨立，斷糧時即使 0 筆也告警。
+    #    #5：master 讀取/檢查失敗（檔不存在/路徑錯/編碼錯）只降級成 warning，
+    #    絕不讓既有 P0 推播流程停止——P0 是主業，新鮮度是附加守望。
     freshness = None
     if master_csv:
-        freshness = check_data_freshness(master_csv, state, dry_run,
-                                         freshness_days, realert_days, today=today)
+        try:
+            freshness = check_data_freshness(master_csv, state, dry_run,
+                                             freshness_days, realert_days, today=today)
+        except Exception as e:  # noqa: BLE001 — 任何 master 端錯誤都不得中斷 P0
+            print(f"::warning::[freshness] 新鮮度檢查失敗、已跳過（不影響 P0）：{e}",
+                  file=sys.stderr)
+            freshness = {"error": str(e), "stale": None, "alerted": False}
 
     rows = read_rows(weekly_csv)
 

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -144,13 +144,15 @@ def find_new_by_batch(rows: list, state: dict):
     當新案窗。改追「已處理過的最新批次 `last_batch`」：只把 **比 last_batch 新的
     批次** 的案子當新案，再經既有 seen_keys 去重（同批次重抓不重推）。
 
-    回傳 (new_rows, mode, cand)：
+    回傳 (new_rows, mode, commit_rows)：
+    commit_rows ＝送達成功後該列入 seen_keys 水位的列（避免下輪重推）。
     - mode='fallback'：rows 完全沒有合法批次訊號（filename 全缺/全髒，非 pcc/舊資料）
-      → 退回既有 seen_keys 水位法，向後相容（不讓無 filename 的資料整批靜默）。
+      → 退回既有 seen_keys 水位法；commit_rows = rows。
     - mode='baseline'：冷啟動（state 從未記 last_batch）或 last_batch 壞掉（非法值，
-      codex #5）→ 只設基線、不回補整個歷史 backlog，本輪不視為新案。
+      codex #5）→ 只設基線、不回補整個歷史 backlog；commit_rows = []。
     - mode='batch'：正常批次偵測。cand＝比 last_batch 新的「合法批次」列；同份資料中
-      無/非法 filename 的列（codex #4）另走 seen_keys 水位法，不被靜默忽略。
+      無/非法 filename 的列（codex #4）另走 seen_keys 水位法。**commit_rows = cand +
+      no_batch**——no_batch 列也要進水位，否則本輪推了下輪又重推（codex 複審）。
     """
     cur = latest_batch(rows)   # 只看合法批次（#3）
     if not cur:
@@ -173,7 +175,9 @@ def find_new_by_batch(rows: list, state: dict):
     new = find_new(cand, state)
     if no_batch:
         new = new + find_new(no_batch, state)
-    return new, "batch", cand
+    # commit_rows 含 no_batch（codex 複審）：否則無 filename 列本輪推了但沒進水位、
+    # 下輪又被當新案重推、new 每輪膨脹。
+    return new, "batch", cand + no_batch
 
 
 def run(weekly_csv: str, state_path: str, dry_run: bool = True,
@@ -210,8 +214,9 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     rows = read_rows(weekly_csv)
     cur_batch = latest_batch(rows)
 
-    # 1. 新案偵測：批次錨（+ seen_keys 去重）；無批次訊號退回水位法
-    new_rows, mode, cand = find_new_by_batch(rows, state)
+    # 1. 新案偵測：批次錨（+ seen_keys 去重）；無批次訊號退回水位法。
+    #    commit_rows＝送達後該列入水位的列（batch 模式含無 filename 的 fallback 列）。
+    new_rows, mode, commit_rows = find_new_by_batch(rows, state)
     # 2. P0 布林過濾
     p0_rows = [r for r in new_rows if is_p0(r)]
 
@@ -249,7 +254,7 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
         仍 save_state 以保住 freshness 節流 / run-log（送失敗不該連帶丟掉）。
         """
         if advance:
-            commit_watermark(cand if mode == "batch" else rows, state)
+            commit_watermark(commit_rows, state)
             if cur_batch:
                 prev = state.get("last_batch", "") or ""
                 state["last_batch"] = max(cur_batch, prev)

--- a/scripts/watcher.py
+++ b/scripts/watcher.py
@@ -16,12 +16,13 @@ import csv
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import date, datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from freshness import check_freshness  # noqa: E402
 from p0_rules import is_p0  # noqa: E402
-from slack_notify import notify  # noqa: E402
+from slack_notify import notify, notify_freshness  # noqa: E402
 from watcher_diff import (  # noqa: E402
     append_runlog,
     commit_watermark,
@@ -33,10 +34,25 @@ from watcher_diff import (  # noqa: E402
 PUSH_CAP = 20          # 單輪推播上限，超過 → 降級 alert 不推
 ALERT_DIR = "data/alerts"
 
+# 資料新鮮度門檻（issue #22）：master 最新 date 距今 > 此天數 → 判定上游斷糧、告警。
+#
+# 為何是 14 而非 brief 初估的 3–5：pcc-tender 是「官方半月公開資料」，正常供料下
+# 最新日期本就會隨發布週期落後。實測健康期（2026 Jan–Apr）master 資料：
+#   - 有料日多為每日/每 1–3 天一筆，
+#   - 但農曆年等假期出現過最大 10 天的資料空窗（2/13→2/23），
+#   - 疊加半月一次的發布節奏，下次發布前最新日期可正常落後到 ~16 天。
+# 門檻設 3–5 會在每個假期/發布前空窗誤報 → 違反「正常供料不誤報」鐵則，
+# 狼來了喊久就被無視＝退回靜默失敗。14 天＝大於實測最壞正常空窗(10)+裕度，
+# 仍能在再次斷糧後約兩週內告警；當前已斷糧 56 天 → 立即觸發。可用 --freshness-days 調。
+FRESHNESS_DAYS = 14
+# 斷糧持續期間的重提間隔（天）：避免長期斷糧每天重複轟炸 Slack。
+# 首次偵測立即推；之後同一停滯狀態每 N 天重提一次（最新日期變動也會重提）。
+FRESHNESS_REALERT_DAYS = 3
+
 
 def write_alert(kind: str, detail: dict) -> str:
     os.makedirs(ALERT_DIR, exist_ok=True)
-    ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+    ts = datetime.now().strftime("%Y%m%dT%H%M%S_%f")  # 含微秒：避免同秒多 alert 覆蓋
     path = os.path.join(ALERT_DIR, f"{ts}-{kind}.json")
     payload = {"ts": datetime.now().isoformat(timespec="seconds"),
                "kind": kind, **detail}
@@ -51,14 +67,67 @@ def read_rows(csv_path: str) -> list:
         return list(csv.DictReader(f))
 
 
+def check_data_freshness(master_csv: str, state: dict, dry_run: bool,
+                         freshness_days: int, realert_days: int,
+                         today: date = None) -> dict:
+    """偵測 master 資料源是否斷糧；stale 時推 Slack 告警（含重提節流）。
+
+    回傳 freshness dict（check_freshness 結果再加 alerted: bool）。
+    節流：同一停滯狀態（latest_date 不變）每 realert_days 天最多重提一次；
+    latest_date 變動（資料前進或回退）視為新狀態，立即重提。
+    """
+    today = today or date.today()
+    rows = read_rows(master_csv)
+    fr = check_freshness(rows, freshness_days, today=today)
+    fr["alerted"] = False
+    if not fr["stale"]:
+        # 恢復供料 → 清掉節流紀錄，下次再斷糧能立即重提
+        state.pop("freshness_alert", None)
+        return fr
+
+    prev = state.get("freshness_alert") or {}
+    prev_latest = prev.get("latest_date")
+    prev_date = prev.get("last_alert_date")
+    should = True
+    if prev_latest == fr["latest_date"] and prev_date:
+        prev_d = datetime.strptime(prev_date, "%Y-%m-%d").date()
+        should = (today - prev_d).days >= realert_days
+
+    if should:
+        write_alert("data_freshness", {
+            "source": "pcc-tender", "latest_date": fr["latest_date"],
+            "age_days": fr["age_days"], "threshold_days": freshness_days,
+            "hint": "上游資料源停滯/斷糧；watcher 本身正常。見 issue #22。",
+        })
+        notify_freshness(fr["latest_date"], fr["age_days"], freshness_days,
+                         dry_run=dry_run)
+        state["freshness_alert"] = {"latest_date": fr["latest_date"],
+                                    "last_alert_date": today.isoformat()}
+        fr["alerted"] = True
+    return fr
+
+
 def run(weekly_csv: str, state_path: str, dry_run: bool = True,
-        push_cap: int = PUSH_CAP) -> dict:
+        push_cap: int = PUSH_CAP, master_csv: str = None,
+        freshness_days: int = FRESHNESS_DAYS,
+        realert_days: int = FRESHNESS_REALERT_DAYS, today: date = None) -> dict:
     """跑一輪 watcher。回傳結果 dict（含 status: ok|capped）。
 
     時間封頂改由 CI step `timeout-minutes` 硬 kill（見 daily-watcher.yml），
     本檔不做軟檢查（純記憶體操作跑不到 300s，軟檢查是擺設；ADR D4）。
+
+    master_csv 有給時，額外做「資料新鮮度檢查」（issue #22）：master 最新日期
+    距今 > freshness_days → 推 Slack 斷糧告警。master_csv=None 時跳過（不影響
+    既有 P0 推播流程與舊測試）。
     """
     state = load_state(state_path)
+
+    # 0. 資料新鮮度檢查（issue #22）：與 P0 流程獨立，斷糧時即使 0 筆也告警。
+    freshness = None
+    if master_csv:
+        freshness = check_data_freshness(master_csv, state, dry_run,
+                                         freshness_days, realert_days, today=today)
+
     rows = read_rows(weekly_csv)
 
     # 1. diff：水位找新出現
@@ -67,7 +136,8 @@ def run(weekly_csv: str, state_path: str, dry_run: bool = True,
     p0_rows = [r for r in new_rows if is_p0(r)]
 
     result = {"fetched": len(rows), "new": len(new_rows),
-              "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None}
+              "p0": len(p0_rows), "pushed": 0, "status": "ok", "alert": None,
+              "freshness": freshness}
 
     # 3. 成本封頂：推播候選過多 → 規則錯/資料異常 → 不推、alert
     #    ⚠️ 0 漏報鐵則（issue #14 §4）：capped 時水位仍前進，被擋的 P0 下輪
@@ -112,10 +182,15 @@ def main():
     ap.add_argument("--push", action="store_true",
                     help="實際推 Slack（預設 dry-run；需 env SLACK_WEBHOOK_URL）")
     ap.add_argument("--push-cap", type=int, default=PUSH_CAP)
+    ap.add_argument("--master", default=None,
+                    help="master 資料集 CSV；給了才做資料新鮮度檢查（issue #22）")
+    ap.add_argument("--freshness-days", type=int, default=FRESHNESS_DAYS,
+                    help=f"資料最新日期距今超過此天數判定斷糧（預設 {FRESHNESS_DAYS}）")
     args = ap.parse_args()
 
     res = run(args.weekly, args.state, dry_run=not args.push,
-              push_cap=args.push_cap)
+              push_cap=args.push_cap, master_csv=args.master,
+              freshness_days=args.freshness_days)
     print(json.dumps(res, ensure_ascii=False), file=sys.stderr)
     # capped 用非零退出碼讓 CI 標記降級（但不算 fetch 失敗）
     if res["status"] == "capped":

--- a/tests/test_fetch_batches.py
+++ b/tests/test_fetch_batches.py
@@ -1,0 +1,27 @@
+"""fetch_pcc 批次抓取純函式 test（issue #22 方案 A）。
+
+只測無網路的純邏輯（pick_latest_batch_keys）：跨 tender_/award_ 前綴統一成
+批次日期段、去重、取最新 n 個。實際對 TwinkleAI 的抓取需 CI（有 token）驗。
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from fetch_pcc import pick_latest_batch_keys  # noqa: E402
+
+
+def test_pick_latest_unifies_prefix_and_dedups():
+    files = ["tender_20260402.xml", "award_20260402.xml",
+             "tender_20260302.xml", "award_20260301.xml"]
+    assert pick_latest_batch_keys(files, 2) == ["20260402", "20260302"]
+
+
+def test_pick_latest_ignores_non_batch_filenames():
+    files = ["junk.xml", "", "tender_20260401.xml", None]
+    assert pick_latest_batch_keys(files, 5) == ["20260401"]
+
+
+def test_pick_latest_limits_n():
+    files = [f"tender_2026{m:02d}02.xml" for m in range(1, 5)]
+    assert pick_latest_batch_keys(files, 2) == ["20260402", "20260302"]

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,0 +1,190 @@
+"""資料新鮮度告警 unit test（issue #22）。
+
+驗收（brief）：
+- master 最新日期 > N 天前 → 推一則 Slack 新鮮度告警（含資料源/最新日期/距今天數）
+- 正常供料時不誤報
+- 有可自動驗證的測試
+"""
+import csv
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import watcher  # noqa: E402
+from freshness import check_freshness, latest_data_date  # noqa: E402
+from slack_notify import build_freshness_payload, notify_freshness  # noqa: E402
+
+TODAY = date(2026, 6, 29)
+
+
+def _rows(*dates):
+    return [{"date": d, "title": "x", "unit_id": "U", "job_number": "J"} for d in dates]
+
+
+def _write_master(path, *dates):
+    cols = ["unit_id", "job_number", "date", "title"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for i, d in enumerate(dates):
+            w.writerow({"unit_id": f"U{i}", "job_number": f"J{i}", "date": d,
+                        "title": f"案{i}"})
+
+
+def _write_weekly(path, n=0):
+    cols = ["unit_id", "job_number", "date", "title", "unit_name", "type",
+            "url", "category"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for i in range(n):
+            w.writerow({"unit_id": f"W{i}", "job_number": f"WJ{i}",
+                        "date": "20260629", "title": "新案", "unit_name": "機關",
+                        "type": "公開招標", "url": "", "category": "勞務類"})
+
+
+# ---------- freshness 純函式 ----------
+def test_latest_data_date_picks_max():
+    assert latest_data_date(_rows("20260101", "20260504", "20260315")) == "20260504"
+
+
+def test_latest_data_date_ignores_dirty():
+    assert latest_data_date(_rows("20260504", "99999999", "", "abc")) == "20260504"
+
+
+def test_check_freshness_stale():
+    fr = check_freshness(_rows("20260504"), 14, today=TODAY)
+    assert fr["stale"] is True and fr["latest_date"] == "20260504"
+    assert fr["age_days"] == 56
+
+
+def test_check_freshness_fresh_within_threshold():
+    # 距今 10 天 < 14 → 不誤報（模擬假期空窗的正常供料）
+    fr = check_freshness(_rows("20260619"), 14, today=TODAY)
+    assert fr["stale"] is False and fr["age_days"] == 10
+
+
+def test_check_freshness_empty_is_stale():
+    fr = check_freshness([], 14, today=TODAY)
+    assert fr["stale"] is True and fr["latest_date"] == "" and fr["age_days"] is None
+
+
+# ---------- Slack payload ----------
+def test_freshness_payload_contains_required_facts():
+    p = build_freshness_payload("20260504", 56, 14, source="pcc-tender")
+    txt = json.dumps(p, ensure_ascii=False)
+    assert "pcc-tender" in txt          # 資料源
+    assert "2026-05-04" in txt          # 最新日期
+    assert "56" in txt                  # 距今天數
+    assert p["blocks"][0]["type"] == "header"
+
+
+def test_notify_freshness_dry_run_no_send():
+    res = notify_freshness("20260504", 56, 14, dry_run=True)
+    assert res["sent"] is False and res["reason"] == "dry_run"
+
+
+def test_notify_freshness_no_webhook_safe_degrade():
+    res = notify_freshness("20260504", 56, 14, dry_run=False, webhook="")
+    assert res["sent"] is False and res["reason"] == "no_webhook"
+
+
+# ---------- watcher 整合 ----------
+def test_run_stale_master_fires_freshness(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    master = tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)               # 斷糧：本輪 0 筆
+    _write_master(master, "20260504")        # master 卡在 56 天前
+    res = watcher.run(str(weekly), str(state), dry_run=True,
+                      master_csv=str(master), today=TODAY)
+    assert res["freshness"]["stale"] is True
+    assert res["freshness"]["alerted"] is True
+    # 寫了 data_freshness alert 檔
+    alerts = list((tmp_path / "alerts").glob("*data_freshness*.json"))
+    assert len(alerts) == 1
+    payload = json.loads(alerts[0].read_text(encoding="utf-8"))
+    assert payload["latest_date"] == "20260504" and payload["age_days"] == 56
+
+
+def test_run_fresh_master_no_alert(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    master = tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260628")        # 1 天前 → 正常
+    res = watcher.run(str(weekly), str(state), dry_run=True,
+                      master_csv=str(master), today=TODAY)
+    assert res["freshness"]["stale"] is False
+    assert res["freshness"]["alerted"] is False
+    assert not list((tmp_path / "alerts").glob("*data_freshness*.json"))
+
+
+def test_run_no_master_skips_freshness(tmp_path):
+    # 不給 master → 完全不做新鮮度檢查（保護既有流程/舊測試）
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    _write_weekly(weekly, n=0)
+    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    assert res["freshness"] is None
+
+
+def test_freshness_realert_throttled(tmp_path, monkeypatch):
+    """同一停滯狀態隔天再跑 → 節流不重複轟炸（< realert_days）。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    master = tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260504")
+    r1 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                     realert_days=3, today=date(2026, 6, 29))
+    r2 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                     realert_days=3, today=date(2026, 6, 30))  # 隔 1 天 < 3
+    assert r1["freshness"]["alerted"] is True
+    assert r2["freshness"]["alerted"] is False
+    # 只寫了 1 個 alert 檔
+    assert len(list((tmp_path / "alerts").glob("*data_freshness*.json"))) == 1
+
+
+def test_freshness_realert_after_interval(tmp_path, monkeypatch):
+    """超過 realert_days 仍斷糧 → 重提一次。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    master = tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260504")
+    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                realert_days=3, today=date(2026, 6, 29))
+    r2 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                     realert_days=3, today=date(2026, 7, 3))  # 隔 4 天 >= 3
+    assert r2["freshness"]["alerted"] is True
+    assert len(list((tmp_path / "alerts").glob("*data_freshness*.json"))) == 2
+
+
+def test_freshness_recovery_clears_throttle(tmp_path, monkeypatch):
+    """斷糧→恢復供料→再斷糧：恢復時清節流，再斷糧能立即重提。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly = tmp_path / "w.csv"
+    state = tmp_path / "s.json"
+    master = tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    # 斷糧
+    _write_master(master, "20260504")
+    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                realert_days=3, today=date(2026, 6, 29))
+    # 恢復供料
+    _write_master(master, "20260629")
+    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                realert_days=3, today=date(2026, 6, 29))
+    # 再次斷糧（同一最新日期但已恢復過）→ 立即重提
+    _write_master(master, "20260504")
+    r = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                    realert_days=3, today=date(2026, 6, 30))
+    assert r["freshness"]["alerted"] is True

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -95,6 +95,7 @@ def test_notify_freshness_no_webhook_safe_degrade():
 # ---------- watcher 整合 ----------
 def test_run_stale_master_fires_freshness(tmp_path, monkeypatch):
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly = tmp_path / "w.csv"
     state = tmp_path / "s.json"
     master = tmp_path / "m.csv"
@@ -137,6 +138,7 @@ def test_run_no_master_skips_freshness(tmp_path):
 def test_freshness_realert_throttled(tmp_path, monkeypatch):
     """同一停滯狀態隔天再跑 → 節流不重複轟炸（< realert_days）。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly = tmp_path / "w.csv"
     state = tmp_path / "s.json"
     master = tmp_path / "m.csv"
@@ -155,6 +157,7 @@ def test_freshness_realert_throttled(tmp_path, monkeypatch):
 def test_freshness_realert_after_interval(tmp_path, monkeypatch):
     """超過 realert_days 仍斷糧 → 重提一次。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly = tmp_path / "w.csv"
     state = tmp_path / "s.json"
     master = tmp_path / "m.csv"
@@ -171,6 +174,7 @@ def test_freshness_realert_after_interval(tmp_path, monkeypatch):
 def test_freshness_recovery_clears_throttle(tmp_path, monkeypatch):
     """斷糧→恢復供料→再斷糧：恢復時清節流，再斷糧能立即重提。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly = tmp_path / "w.csv"
     state = tmp_path / "s.json"
     master = tmp_path / "m.csv"
@@ -197,6 +201,7 @@ def test_dry_run_does_not_consume_throttle_or_write(tmp_path, monkeypatch):
     回歸 codex High#1：dry-run 若更新節流，隨後真推會被 realert_days 壓掉。
     """
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
     _write_master(master, "20260504")
@@ -216,6 +221,7 @@ def test_dry_run_does_not_consume_throttle_or_write(tmp_path, monkeypatch):
 def test_broken_throttle_state_does_not_crash(tmp_path, monkeypatch):
     """#2：壞掉的 watcher_state.json（last_alert_date 非法）不丟例外，視為無節流續推。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
     _write_master(master, "20260504")
@@ -225,6 +231,33 @@ def test_broken_throttle_state_does_not_crash(tmp_path, monkeypatch):
     r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                     realert_days=3, today=TODAY)
     assert r["freshness"]["alerted"] is True   # 壞 state → 當無節流、續推
+
+
+def test_failed_send_does_not_start_throttle(tmp_path, monkeypatch):
+    """codex 複審：實際沒推到 Slack（送失敗/no_webhook）→ 不啟動 3 天節流。
+
+    否則沒送達也消耗 realert 窗 → 告警被靜默壓掉、回到「靜默斷糧」。
+    驗：第一輪沒送達 → 不標 alerted、不寫節流 state；下一輪仍會嘗試推。
+    """
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    # 模擬「沒送達」：no_webhook / 送失敗都回 sent=False
+    monkeypatch.setattr(watcher, "notify_freshness",
+                        lambda *a, **k: {"sent": False, "reason": "no_webhook"})
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260504")
+    r1 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                     realert_days=3, today=date(2026, 6, 29))
+    assert r1["freshness"]["alerted"] is False                # 沒送達 → 未標已通知
+    saved = json.loads(state.read_text(encoding="utf-8")) if state.exists() else {}
+    assert "freshness_alert" not in saved                     # 節流 state 未被設
+    # alert 檔仍留痕（可追）
+    assert list((tmp_path / "alerts").glob("*data_freshness*.json"))
+    # 下一輪（隔 1 天 < realert）仍會嘗試推（沒被節流壓掉）→ 換成送達成功就 alert
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
+    r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                     realert_days=3, today=date(2026, 6, 30))
+    assert r2["freshness"]["alerted"] is True                 # 未被節流，重試成功
 
 
 def test_master_read_failure_does_not_break_p0(tmp_path, monkeypatch):

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -244,6 +244,9 @@ def test_mixed_filename_no_batch_rows_not_silently_dropped(tmp_path, monkeypatch
                     "url": "", "category": "勞務類", "filename": ""})
     res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
     assert res["new"] == 2 and res["pushed"] == 2   # 批次列 + 無 filename 列都被推
+    # 複審修正：第二輪同檔 → 無 filename 列也已進水位，不再重推
+    r2 = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
+    assert r2["new"] == 0 and r2["pushed"] == 0
 
 
 def test_broken_cursor_resets_baseline(tmp_path, monkeypatch):

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -137,38 +137,125 @@ def test_notify_freshness_no_webhook_safe_degrade():
     assert res["sent"] is False and res["reason"] == "no_webhook"
 
 
-# ---------- watcher 批次新案偵測 ----------
+# ---------- watcher 批次新案偵測（真跑路徑：dry-run 唯讀不持久化）----------
+def _mock_sent(monkeypatch):
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True, "reason": "ok"})
+
+
 def test_cold_start_sets_baseline_no_push(tmp_path):
     """冷啟動：只設批次基線、不回補歷史 backlog、不推。"""
     weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
     _write_weekly(weekly, batch="tender_20260402.xml", n=3)
-    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
     assert res["baseline"] is True and res["new"] == 0 and res["pushed"] == 0
     saved = json.loads(state.read_text(encoding="utf-8"))
     assert saved["last_batch"] == "20260402"   # 基線已記
 
 
-def test_new_batch_detected_and_pushed(tmp_path):
+def test_new_batch_detected_and_pushed(tmp_path, monkeypatch):
     """已處理到 0401，出現 0402 新批次 → 該批 P0 被推。"""
+    _mock_sent(monkeypatch)
     weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
     _write_weekly(weekly, batch="tender_20260401.xml", n=1)
-    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # baseline 0401
+    watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)   # baseline 0401
     _write_weekly(weekly, batch="tender_20260402.xml", n=2)
-    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
     assert res["baseline"] is False and res["new"] == 2 and res["p0"] == 2
     assert res["pushed"] == 2 and res["batch"] == "20260402"
     assert json.loads(state.read_text(encoding="utf-8"))["last_batch"] == "20260402"
 
 
-def test_same_batch_not_repushed(tmp_path):
+def test_same_batch_not_repushed(tmp_path, monkeypatch):
     """同一批次再跑 → 不重複當新案。"""
+    _mock_sent(monkeypatch)
     weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
     _write_weekly(weekly, batch="tender_20260401.xml", n=1)
-    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # baseline 0401
+    watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)   # baseline 0401
     _write_weekly(weekly, batch="tender_20260402.xml", n=1)
-    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # 推 0402
-    r3 = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)  # 再跑同批
+    watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)   # 推 0402
+    r3 = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)  # 再跑同批
     assert r3["new"] == 0 and r3["pushed"] == 0
+
+
+# ---------- codex 批次重寫 5 點修正回歸 ----------
+def test_dry_run_does_not_persist_state(tmp_path):
+    """#1：dry-run 唯讀——不推進游標、不寫 state（manual dispatch commit 不毒化）。"""
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260402.xml", n=2)
+    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    assert res["pushed"] == 2 or res["baseline"]   # 回報 would-push
+    assert not state.exists()                        # 完全沒寫 state
+
+
+def test_failed_push_does_not_advance_cursor(tmp_path, monkeypatch):
+    """#1：真推但 Slack 送失敗 → 不推進游標、下輪重抓重試。"""
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260401.xml", n=1)
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True})
+    watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)   # baseline 0401
+    _write_weekly(weekly, batch="tender_20260402.xml", n=1)
+    monkeypatch.setattr(watcher, "notify",
+                        lambda *a, **k: {"sent": False, "reason": "no_webhook"})
+    r1 = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)  # 送失敗
+    assert r1["pushed"] == 0
+    assert json.loads(state.read_text(encoding="utf-8"))["last_batch"] == "20260401"
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True})
+    r2 = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)  # 重試送達
+    assert r2["new"] == 1 and r2["pushed"] == 1
+    assert json.loads(state.read_text(encoding="utf-8"))["last_batch"] == "20260402"
+
+
+def test_batch_gap_detected_and_alerted(tmp_path, monkeypatch):
+    """#2：游標停在 0301，這輪只抓到 0402（中間 0302/0401 沒抓）→ 缺口告警。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True})
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    state.write_text(json.dumps({"last_batch": "20260301", "seen_keys": [],
+                                 "runs": []}), encoding="utf-8")
+    _write_weekly(weekly, batch="tender_20260402.xml", n=1)   # 只抓到 1 批、期距 3
+    res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
+    assert res["gap"] is True and res["alert"] == "batch_gap"
+    assert list((tmp_path / "alerts").glob("*batch_gap*.json"))
+
+
+def test_invalid_batch_key_not_cursor():
+    """#3：非法 filename（half 03 / 月 13）不進游標、不被當最新批次。"""
+    from freshness import valid_batch_key
+    assert valid_batch_key("tender_20260403.xml") == ""   # half 03 非法
+    assert valid_batch_key("tender_20261302.xml") == ""   # 月 13 非法
+    rows = [{"filename": "tender_20260403.xml"}, {"filename": "tender_20260302.xml"}]
+    assert latest_batch(rows) == "20260302"   # 非法值不灌頂
+
+
+def test_mixed_filename_no_batch_rows_not_silently_dropped(tmp_path, monkeypatch):
+    """#4：同份資料部分無 filename 的列改走水位法，不被靜默忽略。"""
+    _mock_sent(monkeypatch)
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260401.xml", n=1)
+    watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)   # baseline 0401
+    with open(weekly, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=WEEKLY_COLS)
+        w.writeheader()
+        w.writerow({"unit_id": "B1", "job_number": "BJ1", "date": "20260315",
+                    "title": "資訊系統開發", "unit_name": "經濟部", "type": "公開招標",
+                    "url": "", "category": "勞務類", "filename": "tender_20260402.xml"})
+        w.writerow({"unit_id": "N1", "job_number": "NJ1", "date": "20260315",
+                    "title": "資訊系統開發", "unit_name": "經濟部", "type": "公開招標",
+                    "url": "", "category": "勞務類", "filename": ""})
+    res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
+    assert res["new"] == 2 and res["pushed"] == 2   # 批次列 + 無 filename 列都被推
+
+
+def test_broken_cursor_resets_baseline(tmp_path, monkeypatch):
+    """#5：壞掉的 last_batch（非法值）→ 重設基線、不靜默漏報。"""
+    _mock_sent(monkeypatch)
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    state.write_text(json.dumps({"last_batch": "garbage", "seen_keys": [],
+                                 "runs": []}), encoding="utf-8")
+    _write_weekly(weekly, batch="tender_20260402.xml", n=2)
+    res = watcher.run(str(weekly), str(state), dry_run=False, today=TODAY)
+    assert res["baseline"] is True   # 壞游標 → 重設基線
+    assert json.loads(state.read_text(encoding="utf-8"))["last_batch"] == "20260402"
 
 
 # ---------- watcher 新鮮度整合 ----------

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,9 +1,10 @@
-"""資料新鮮度告警 unit test（issue #22）。
+"""資料新鮮度告警 + 批次新案偵測 unit test（issue #22，方案 A 批次節奏版）。
 
-驗收（brief）：
-- master 最新日期 > N 天前 → 推一則 Slack 新鮮度告警（含資料源/最新日期/距今天數）
-- 正常供料時不誤報
-- 有可自動驗證的測試
+根因翻轉後（見 ADR 0003）：官方天生 ~2 月延遲、半月批次發布（filename=YYYYMM0H）。
+- 新案偵測：以批次 filename 為錨，只推「比已處理批次新」的批次（廢除公告日窗）。
+- 新鮮度：以「最新批次有沒有如期出現」判，不用公告日距今。
+- 保留 PR #23 健壯性：節流(只在 sent=True)/dry-run 無副作用/Asia-Taipei/webhook 邊界/
+  壞 state 不 crash/master 失敗不中斷 P0。
 """
 import csv
 import json
@@ -14,281 +15,309 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import watcher  # noqa: E402
-from freshness import check_freshness, latest_data_date  # noqa: E402
+from freshness import (  # noqa: E402
+    batch_key,
+    batch_period,
+    check_batch_freshness,
+    expected_latest_batch_period,
+    latest_batch,
+    period_to_key,
+    taipei_today,
+)
 from slack_notify import build_freshness_payload, notify_freshness  # noqa: E402
 
-TODAY = date(2026, 6, 29)
+TODAY = date(2026, 6, 29)   # 預期最新批次 = 2026-04 下半月（20260402）
+
+MASTER_COLS = ["unit_id", "job_number", "date", "title", "filename"]
+WEEKLY_COLS = ["unit_id", "job_number", "date", "title", "unit_name", "type",
+               "url", "category", "filename"]
 
 
-def _rows(*dates):
-    return [{"date": d, "title": "x", "unit_id": "U", "job_number": "J"} for d in dates]
+def _master_rows(*batch_files):
+    return [{"unit_id": f"U{i}", "job_number": f"J{i}", "date": "20260301",
+             "title": f"案{i}", "filename": fn} for i, fn in enumerate(batch_files)]
 
 
-def _write_master(path, *dates):
-    cols = ["unit_id", "job_number", "date", "title"]
+def _write_master(path, *batch_files):
     with open(path, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=cols)
+        w = csv.DictWriter(f, fieldnames=MASTER_COLS)
         w.writeheader()
-        for i, d in enumerate(dates):
-            w.writerow({"unit_id": f"U{i}", "job_number": f"J{i}", "date": d,
-                        "title": f"案{i}"})
+        for r in _master_rows(*batch_files):
+            w.writerow(r)
 
 
-def _write_weekly(path, n=0):
-    cols = ["unit_id", "job_number", "date", "title", "unit_name", "type",
-            "url", "category"]
+def _write_weekly(path, batch=None, n=0):
+    """寫 n 筆 P0 候選（勞務類 + 軟體關鍵字 + 白名單機關），都屬批次 batch。"""
     with open(path, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=cols)
+        w = csv.DictWriter(f, fieldnames=WEEKLY_COLS)
         w.writeheader()
         for i in range(n):
             w.writerow({"unit_id": f"W{i}", "job_number": f"WJ{i}",
-                        "date": "20260629", "title": "新案", "unit_name": "機關",
-                        "type": "公開招標", "url": "", "category": "勞務類"})
+                        "date": "20260315", "title": "資訊系統開發",
+                        "unit_name": "經濟部", "type": "公開招標",
+                        "url": "", "category": "勞務類",
+                        "filename": batch or "tender_20260402.xml"})
 
 
-# ---------- freshness 純函式 ----------
-def test_latest_data_date_picks_max():
-    assert latest_data_date(_rows("20260101", "20260504", "20260315")) == "20260504"
+# ---------- 批次識別純函式 ----------
+def test_batch_key_strips_prefix():
+    assert batch_key("tender_20260402.xml") == "20260402"
+    assert batch_key("award_20260402.xml") == "20260402"   # 跨前綴統一
+    assert batch_key("") == "" and batch_key("nope.xml") == ""
 
 
-def test_latest_data_date_ignores_dirty():
-    assert latest_data_date(_rows("20260504", "99999999", "", "abc")) == "20260504"
+def test_batch_period_and_roundtrip():
+    p = batch_period("20260402")            # 4 月下半月
+    assert p == 2026 * 24 + (4 - 1) * 2 + 1
+    assert period_to_key(p) == "20260402"
+    assert batch_period("20260401") == p - 1   # 相鄰半月差 1
+    assert period_to_key(p - 1) == "20260401"
 
 
-def test_check_freshness_stale():
-    fr = check_freshness(_rows("20260504"), 14, today=TODAY)
-    assert fr["stale"] is True and fr["latest_date"] == "20260504"
-    assert fr["age_days"] == 56
+def test_batch_period_rejects_dirty():
+    assert batch_period("20261302") is None   # 月 13 非法
+    assert batch_period("20260403") is None   # half 03 非法（僅 01/02）
+    assert batch_period("abc") is None and batch_period("") is None
 
 
-def test_check_freshness_fresh_within_threshold():
-    # 距今 10 天 < 14 → 不誤報（模擬假期空窗的正常供料）
-    fr = check_freshness(_rows("20260619"), 14, today=TODAY)
-    assert fr["stale"] is False and fr["age_days"] == 10
+def test_latest_batch_picks_max_across_prefix():
+    rows = [{"filename": "tender_20260302.xml"}, {"filename": "award_20260402.xml"},
+            {"filename": "tender_20260401.xml"}]
+    assert latest_batch(rows) == "20260402"
 
 
-def test_check_freshness_empty_is_stale():
-    fr = check_freshness([], 14, today=TODAY)
-    assert fr["stale"] is True and fr["latest_date"] == "" and fr["age_days"] is None
+def test_expected_latest_batch_cadence():
+    # 6/29（>=5 號）→ 預期 4 月下半月（今天 -2 月）
+    assert period_to_key(expected_latest_batch_period(date(2026, 6, 29))) == "20260402"
+    # 6/3（<5 號，發布日前）→ 保守抓 3 月下半月（今天 -3 月）
+    assert period_to_key(expected_latest_batch_period(date(2026, 6, 3))) == "20260302"
+
+
+# ---------- check_batch_freshness ----------
+def test_freshness_stale_when_behind_two_periods():
+    # TwinkleAI 卡 20260302、預期 20260402 → 落後 2 期 → 斷糧（實證情境）
+    fr = check_batch_freshness(_master_rows("tender_20260302.xml"), today=TODAY)
+    assert fr["stale"] is True
+    assert fr["latest_batch"] == "20260302" and fr["expected_batch"] == "20260402"
+    assert fr["lag_periods"] == 2
+
+
+def test_freshness_fresh_when_on_cadence():
+    fr = check_batch_freshness(_master_rows("award_20260402.xml"), today=TODAY)
+    assert fr["stale"] is False and fr["lag_periods"] == 0
+
+
+def test_freshness_tolerates_one_period_lag():
+    # 落後 1 期（剛好某半月還沒發）→ 不誤報
+    fr = check_batch_freshness(_master_rows("tender_20260401.xml"), today=TODAY)
+    assert fr["lag_periods"] == 1 and fr["stale"] is False
+
+
+def test_freshness_empty_is_stale():
+    fr = check_batch_freshness([], today=TODAY)
+    assert fr["stale"] is True and fr["latest_batch"] == "" and fr["lag_periods"] is None
 
 
 # ---------- Slack payload ----------
-def test_freshness_payload_contains_required_facts():
-    p = build_freshness_payload("20260504", 56, 14, source="pcc-tender")
+def test_freshness_payload_contains_batch_facts():
+    p = build_freshness_payload("20260302", "20260402", 2)
     txt = json.dumps(p, ensure_ascii=False)
-    assert "pcc-tender" in txt          # 資料源
-    assert "2026-05-04" in txt          # 最新日期
-    assert "56" in txt                  # 距今天數
+    assert "pcc-tender" in txt and "20260302" in txt and "20260402" in txt
+    assert "2026-03" in txt and "2026-04" in txt     # 人話化批次
     assert p["blocks"][0]["type"] == "header"
 
 
 def test_notify_freshness_dry_run_no_send():
-    res = notify_freshness("20260504", 56, 14, dry_run=True)
+    res = notify_freshness("20260302", "20260402", 2, dry_run=True)
     assert res["sent"] is False and res["reason"] == "dry_run"
 
 
 def test_notify_freshness_no_webhook_safe_degrade():
-    res = notify_freshness("20260504", 56, 14, dry_run=False, webhook="")
+    res = notify_freshness("20260302", "20260402", 2, dry_run=False, webhook="")
     assert res["sent"] is False and res["reason"] == "no_webhook"
 
 
-# ---------- watcher 整合 ----------
+# ---------- watcher 批次新案偵測 ----------
+def test_cold_start_sets_baseline_no_push(tmp_path):
+    """冷啟動：只設批次基線、不回補歷史 backlog、不推。"""
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260402.xml", n=3)
+    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    assert res["baseline"] is True and res["new"] == 0 and res["pushed"] == 0
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert saved["last_batch"] == "20260402"   # 基線已記
+
+
+def test_new_batch_detected_and_pushed(tmp_path):
+    """已處理到 0401，出現 0402 新批次 → 該批 P0 被推。"""
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260401.xml", n=1)
+    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # baseline 0401
+    _write_weekly(weekly, batch="tender_20260402.xml", n=2)
+    res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
+    assert res["baseline"] is False and res["new"] == 2 and res["p0"] == 2
+    assert res["pushed"] == 2 and res["batch"] == "20260402"
+    assert json.loads(state.read_text(encoding="utf-8"))["last_batch"] == "20260402"
+
+
+def test_same_batch_not_repushed(tmp_path):
+    """同一批次再跑 → 不重複當新案。"""
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, batch="tender_20260401.xml", n=1)
+    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # baseline 0401
+    _write_weekly(weekly, batch="tender_20260402.xml", n=1)
+    watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)   # 推 0402
+    r3 = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)  # 再跑同批
+    assert r3["new"] == 0 and r3["pushed"] == 0
+
+
+# ---------- watcher 新鮮度整合 ----------
 def test_run_stale_master_fires_freshness(tmp_path, monkeypatch):
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
-    master = tmp_path / "m.csv"
-    _write_weekly(weekly, n=0)               # 斷糧：本輪 0 筆
-    _write_master(master, "20260504")        # master 卡在 56 天前
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "tender_20260302.xml")   # 卡 3 月下半月 → 落後 2 期
     res = watcher.run(str(weekly), str(state), dry_run=False,
                       master_csv=str(master), today=TODAY)
-    assert res["freshness"]["stale"] is True
-    assert res["freshness"]["alerted"] is True
-    # 寫了 data_freshness alert 檔
+    assert res["freshness"]["stale"] is True and res["freshness"]["alerted"] is True
     alerts = list((tmp_path / "alerts").glob("*data_freshness*.json"))
     assert len(alerts) == 1
     payload = json.loads(alerts[0].read_text(encoding="utf-8"))
-    assert payload["latest_date"] == "20260504" and payload["age_days"] == 56
+    assert payload["latest_batch"] == "20260302" and payload["lag_periods"] == 2
 
 
 def test_run_fresh_master_no_alert(tmp_path, monkeypatch):
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
-    master = tmp_path / "m.csv"
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260628")        # 1 天前 → 正常
+    _write_master(master, "award_20260402.xml")     # 如期 → 不報
     res = watcher.run(str(weekly), str(state), dry_run=True,
                       master_csv=str(master), today=TODAY)
-    assert res["freshness"]["stale"] is False
-    assert res["freshness"]["alerted"] is False
+    assert res["freshness"]["stale"] is False and res["freshness"]["alerted"] is False
     assert not list((tmp_path / "alerts").glob("*data_freshness*.json"))
 
 
 def test_run_no_master_skips_freshness(tmp_path):
-    # 不給 master → 完全不做新鮮度檢查（保護既有流程/舊測試）
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
     _write_weekly(weekly, n=0)
     res = watcher.run(str(weekly), str(state), dry_run=True, today=TODAY)
     assert res["freshness"] is None
 
 
 def test_freshness_realert_throttled(tmp_path, monkeypatch):
-    """同一停滯狀態隔天再跑 → 節流不重複轟炸（< realert_days）。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
-    master = tmp_path / "m.csv"
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260504")
+    _write_master(master, "tender_20260302.xml")
     r1 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 6, 29))
     r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
-                     realert_days=3, today=date(2026, 6, 30))  # 隔 1 天 < 3
+                     realert_days=3, today=date(2026, 6, 30))   # 隔 1 天 < 3
     assert r1["freshness"]["alerted"] is True
     assert r2["freshness"]["alerted"] is False
-    # 只寫了 1 個 alert 檔
     assert len(list((tmp_path / "alerts").glob("*data_freshness*.json"))) == 1
 
 
 def test_freshness_realert_after_interval(tmp_path, monkeypatch):
-    """超過 realert_days 仍斷糧 → 重提一次。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
-    master = tmp_path / "m.csv"
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260504")
+    _write_master(master, "tender_20260302.xml")
     watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                 realert_days=3, today=date(2026, 6, 29))
     r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
-                     realert_days=3, today=date(2026, 7, 3))  # 隔 4 天 >= 3
+                     realert_days=3, today=date(2026, 7, 3))    # 隔 4 天 >= 3
     assert r2["freshness"]["alerted"] is True
     assert len(list((tmp_path / "alerts").glob("*data_freshness*.json"))) == 2
 
 
 def test_freshness_recovery_clears_throttle(tmp_path, monkeypatch):
-    """斷糧→恢復供料→再斷糧：恢復時清節流，再斷糧能立即重提。"""
-    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
-    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
-    weekly = tmp_path / "w.csv"
-    state = tmp_path / "s.json"
-    master = tmp_path / "m.csv"
-    _write_weekly(weekly, n=0)
-    # 斷糧
-    _write_master(master, "20260504")
-    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
-                realert_days=3, today=date(2026, 6, 29))
-    # 恢復供料
-    _write_master(master, "20260629")
-    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
-                realert_days=3, today=date(2026, 6, 29))
-    # 再次斷糧（同一最新日期但已恢復過）→ 立即重提
-    _write_master(master, "20260504")
-    r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
-                    realert_days=3, today=date(2026, 6, 30))
-    assert r["freshness"]["alerted"] is True
-
-
-# ---------- codex 跨模型審查 7 點修正回歸（issue #22）----------
-def test_dry_run_does_not_consume_throttle_or_write(tmp_path, monkeypatch):
-    """#1：dry-run 只回報 would_alert，不寫 alert 檔、不更新節流 state。
-
-    回歸 codex High#1：dry-run 若更新節流，隨後真推會被 realert_days 壓掉。
-    """
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260504")
+    _write_master(master, "tender_20260302.xml")            # 斷糧
+    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                realert_days=3, today=date(2026, 6, 29))
+    _write_master(master, "award_20260402.xml")             # 恢復如期
+    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                realert_days=3, today=date(2026, 6, 29))
+    _write_master(master, "tender_20260302.xml")            # 再斷糧（同批次）
+    r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                    realert_days=3, today=date(2026, 6, 30))
+    assert r["freshness"]["alerted"] is True   # 恢復清了節流 → 立即重提
+
+
+# ---------- PR #23 健壯性回歸（沿用，改批次語意）----------
+def test_dry_run_does_not_consume_throttle_or_write(tmp_path, monkeypatch):
+    """#1：dry-run 只回報 would_alert，不寫 alert 檔、不更新節流 state。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "tender_20260302.xml")
     dr = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
                      realert_days=3, today=TODAY)
-    assert dr["freshness"]["would_alert"] is True   # 會 alert（若真推）
-    assert dr["freshness"]["alerted"] is False       # 但 dry-run 沒真推
-    assert not list((tmp_path / "alerts").glob("*data_freshness*.json"))  # 沒寫檔
-    assert not state.exists() or "freshness_alert" not in json.loads(
-        state.read_text(encoding="utf-8"))            # 沒污染節流 state
-    # 隨後真推不被 dry-run 壓掉 → 仍 alert
+    assert dr["freshness"]["would_alert"] is True and dr["freshness"]["alerted"] is False
+    assert not list((tmp_path / "alerts").glob("*data_freshness*.json"))
+    saved = json.loads(state.read_text(encoding="utf-8")) if state.exists() else {}
+    assert "freshness_alert" not in saved
     real = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                        realert_days=3, today=TODAY)
-    assert real["freshness"]["alerted"] is True
+    assert real["freshness"]["alerted"] is True   # 真推不被 dry-run 壓掉
 
 
 def test_broken_throttle_state_does_not_crash(tmp_path, monkeypatch):
-    """#2：壞掉的 watcher_state.json（last_alert_date 非法）不丟例外，視為無節流續推。"""
+    """#2：壞掉的節流紀錄（last_alert_date 非法）不丟例外、視為無節流續推。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260504")
+    _write_master(master, "tender_20260302.xml")
     state.write_text(json.dumps({"freshness_alert": {
-        "latest_date": "20260504", "last_alert_date": "not-a-date"}}),
+        "latest_batch": "20260302", "last_alert_date": "not-a-date"}}),
         encoding="utf-8")
     r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                     realert_days=3, today=TODAY)
-    assert r["freshness"]["alerted"] is True   # 壞 state → 當無節流、續推
+    assert r["freshness"]["alerted"] is True
 
 
 def test_failed_send_does_not_start_throttle(tmp_path, monkeypatch):
-    """codex 複審：實際沒推到 Slack（送失敗/no_webhook）→ 不啟動 3 天節流。
-
-    否則沒送達也消耗 realert 窗 → 告警被靜默壓掉、回到「靜默斷糧」。
-    驗：第一輪沒送達 → 不標 alerted、不寫節流 state；下一輪仍會嘗試推。
-    """
+    """codex 複審：沒推到 Slack（sent=False）→ 不啟動節流，下輪仍會重試。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
-    # 模擬「沒送達」：no_webhook / 送失敗都回 sent=False
     monkeypatch.setattr(watcher, "notify_freshness",
                         lambda *a, **k: {"sent": False, "reason": "no_webhook"})
     weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
-    _write_master(master, "20260504")
+    _write_master(master, "tender_20260302.xml")
     r1 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 6, 29))
-    assert r1["freshness"]["alerted"] is False                # 沒送達 → 未標已通知
+    assert r1["freshness"]["alerted"] is False
     saved = json.loads(state.read_text(encoding="utf-8")) if state.exists() else {}
-    assert "freshness_alert" not in saved                     # 節流 state 未被設
-    # alert 檔仍留痕（可追）
-    assert list((tmp_path / "alerts").glob("*data_freshness*.json"))
-    # 下一輪（隔 1 天 < realert）仍會嘗試推（沒被節流壓掉）→ 換成送達成功就 alert
+    assert "freshness_alert" not in saved
+    assert list((tmp_path / "alerts").glob("*data_freshness*.json"))   # 仍留痕
     monkeypatch.setattr(watcher, "notify_freshness", lambda *a, **k: {"sent": True})
     r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 6, 30))
-    assert r2["freshness"]["alerted"] is True                 # 未被節流，重試成功
+    assert r2["freshness"]["alerted"] is True   # 未被節流，重試成功
 
 
 def test_master_read_failure_does_not_break_p0(tmp_path, monkeypatch):
-    """#5：master 不存在 → 新鮮度降級成 warning，P0 流程仍正常跑完。"""
+    """#5：master 不存在 → 新鮮度降級 warning，P0 流程仍跑完。"""
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
-    _write_weekly(weekly, n=1)                       # 有 1 筆 P0
+    _write_weekly(weekly, batch="tender_20260402.xml", n=1)
     res = watcher.run(str(weekly), str(state), dry_run=True,
-                      master_csv=str(tmp_path / "does_not_exist.csv"), today=TODAY)
-    assert res["status"] == "ok"                     # P0 流程沒被中斷
-    assert res["freshness"].get("error")             # 新鮮度只記 error
-    assert res["fetched"] == 1                        # weekly 1 筆有讀進來、流程跑完
-    assert isinstance(res["p0"], int)                # P0 仍正常算出（未崩）
-
-
-def test_future_date_does_not_mask_staleness(tmp_path):
-    """#4：未來日期髒行（20991231）不得成為最大日期遮蔽真斷糧。"""
-    fr = check_freshness(_rows("20260504", "20991231"), 14, today=TODAY)
-    assert fr["latest_date"] == "20260504"           # 忽略未來日期
-    assert fr["stale"] is True and fr["age_days"] == 56
-
-
-def test_latest_data_date_filters_future_when_today_given():
-    assert latest_data_date(_rows("20260504", "20991231"), today=TODAY) == "20260504"
-    # 不給 today → 維持舊行為（不過濾，向後相容）
-    assert latest_data_date(_rows("20260504", "20991231")) == "20991231"
+                      master_csv=str(tmp_path / "nope.csv"), today=TODAY)
+    assert res["status"] == "ok" and res["freshness"].get("error")
+    assert res["fetched"] == 1 and isinstance(res["p0"], int)
 
 
 def test_taipei_today_used_by_default():
     """#6：taipei_today 用 Asia/Taipei，不是 UTC date.today。"""
-    from freshness import taipei_today
     import datetime as _dt
     try:
         from zoneinfo import ZoneInfo
@@ -298,7 +327,7 @@ def test_taipei_today_used_by_default():
 
 
 def test_notify_freshness_empty_webhook_no_send_even_with_env(monkeypatch):
-    """#7：明確傳 webhook='' → 不 fallback env、不送（測試環境有 env 也不誤送）。"""
+    """#7：明確傳 webhook='' → 不 fallback env、不送。"""
     monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/should-not-be-used")
-    res = notify_freshness("20260504", 56, 14, dry_run=False, webhook="")
+    res = notify_freshness("20260302", "20260402", 2, dry_run=False, webhook="")
     assert res["sent"] is False and res["reason"] == "no_webhook"

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -100,7 +100,7 @@ def test_run_stale_master_fires_freshness(tmp_path, monkeypatch):
     master = tmp_path / "m.csv"
     _write_weekly(weekly, n=0)               # 斷糧：本輪 0 筆
     _write_master(master, "20260504")        # master 卡在 56 天前
-    res = watcher.run(str(weekly), str(state), dry_run=True,
+    res = watcher.run(str(weekly), str(state), dry_run=False,
                       master_csv=str(master), today=TODAY)
     assert res["freshness"]["stale"] is True
     assert res["freshness"]["alerted"] is True
@@ -142,9 +142,9 @@ def test_freshness_realert_throttled(tmp_path, monkeypatch):
     master = tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
     _write_master(master, "20260504")
-    r1 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    r1 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 6, 29))
-    r2 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 6, 30))  # 隔 1 天 < 3
     assert r1["freshness"]["alerted"] is True
     assert r2["freshness"]["alerted"] is False
@@ -160,9 +160,9 @@ def test_freshness_realert_after_interval(tmp_path, monkeypatch):
     master = tmp_path / "m.csv"
     _write_weekly(weekly, n=0)
     _write_master(master, "20260504")
-    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                 realert_days=3, today=date(2026, 6, 29))
-    r2 = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    r2 = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                      realert_days=3, today=date(2026, 7, 3))  # 隔 4 天 >= 3
     assert r2["freshness"]["alerted"] is True
     assert len(list((tmp_path / "alerts").glob("*data_freshness*.json"))) == 2
@@ -177,14 +177,95 @@ def test_freshness_recovery_clears_throttle(tmp_path, monkeypatch):
     _write_weekly(weekly, n=0)
     # 斷糧
     _write_master(master, "20260504")
-    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                 realert_days=3, today=date(2026, 6, 29))
     # 恢復供料
     _write_master(master, "20260629")
-    watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                 realert_days=3, today=date(2026, 6, 29))
     # 再次斷糧（同一最新日期但已恢復過）→ 立即重提
     _write_master(master, "20260504")
-    r = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+    r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
                     realert_days=3, today=date(2026, 6, 30))
     assert r["freshness"]["alerted"] is True
+
+
+# ---------- codex 跨模型審查 7 點修正回歸（issue #22）----------
+def test_dry_run_does_not_consume_throttle_or_write(tmp_path, monkeypatch):
+    """#1：dry-run 只回報 would_alert，不寫 alert 檔、不更新節流 state。
+
+    回歸 codex High#1：dry-run 若更新節流，隨後真推會被 realert_days 壓掉。
+    """
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260504")
+    dr = watcher.run(str(weekly), str(state), dry_run=True, master_csv=str(master),
+                     realert_days=3, today=TODAY)
+    assert dr["freshness"]["would_alert"] is True   # 會 alert（若真推）
+    assert dr["freshness"]["alerted"] is False       # 但 dry-run 沒真推
+    assert not list((tmp_path / "alerts").glob("*data_freshness*.json"))  # 沒寫檔
+    assert not state.exists() or "freshness_alert" not in json.loads(
+        state.read_text(encoding="utf-8"))            # 沒污染節流 state
+    # 隨後真推不被 dry-run 壓掉 → 仍 alert
+    real = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                       realert_days=3, today=TODAY)
+    assert real["freshness"]["alerted"] is True
+
+
+def test_broken_throttle_state_does_not_crash(tmp_path, monkeypatch):
+    """#2：壞掉的 watcher_state.json（last_alert_date 非法）不丟例外，視為無節流續推。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly, state, master = tmp_path / "w.csv", tmp_path / "s.json", tmp_path / "m.csv"
+    _write_weekly(weekly, n=0)
+    _write_master(master, "20260504")
+    state.write_text(json.dumps({"freshness_alert": {
+        "latest_date": "20260504", "last_alert_date": "not-a-date"}}),
+        encoding="utf-8")
+    r = watcher.run(str(weekly), str(state), dry_run=False, master_csv=str(master),
+                    realert_days=3, today=TODAY)
+    assert r["freshness"]["alerted"] is True   # 壞 state → 當無節流、續推
+
+
+def test_master_read_failure_does_not_break_p0(tmp_path, monkeypatch):
+    """#5：master 不存在 → 新鮮度降級成 warning，P0 流程仍正常跑完。"""
+    monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
+    weekly, state = tmp_path / "w.csv", tmp_path / "s.json"
+    _write_weekly(weekly, n=1)                       # 有 1 筆 P0
+    res = watcher.run(str(weekly), str(state), dry_run=True,
+                      master_csv=str(tmp_path / "does_not_exist.csv"), today=TODAY)
+    assert res["status"] == "ok"                     # P0 流程沒被中斷
+    assert res["freshness"].get("error")             # 新鮮度只記 error
+    assert res["fetched"] == 1                        # weekly 1 筆有讀進來、流程跑完
+    assert isinstance(res["p0"], int)                # P0 仍正常算出（未崩）
+
+
+def test_future_date_does_not_mask_staleness(tmp_path):
+    """#4：未來日期髒行（20991231）不得成為最大日期遮蔽真斷糧。"""
+    fr = check_freshness(_rows("20260504", "20991231"), 14, today=TODAY)
+    assert fr["latest_date"] == "20260504"           # 忽略未來日期
+    assert fr["stale"] is True and fr["age_days"] == 56
+
+
+def test_latest_data_date_filters_future_when_today_given():
+    assert latest_data_date(_rows("20260504", "20991231"), today=TODAY) == "20260504"
+    # 不給 today → 維持舊行為（不過濾，向後相容）
+    assert latest_data_date(_rows("20260504", "20991231")) == "20991231"
+
+
+def test_taipei_today_used_by_default():
+    """#6：taipei_today 用 Asia/Taipei，不是 UTC date.today。"""
+    from freshness import taipei_today
+    import datetime as _dt
+    try:
+        from zoneinfo import ZoneInfo
+        assert taipei_today() == _dt.datetime.now(ZoneInfo("Asia/Taipei")).date()
+    except Exception:
+        assert taipei_today() == _dt.date.today()
+
+
+def test_notify_freshness_empty_webhook_no_send_even_with_env(monkeypatch):
+    """#7：明確傳 webhook='' → 不 fallback env、不送（測試環境有 env 也不誤送）。"""
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/should-not-be-used")
+    res = notify_freshness("20260504", 56, 14, dry_run=False, webhook="")
+    assert res["sent"] is False and res["reason"] == "no_webhook"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -68,12 +68,14 @@ def test_run_filters_non_p0(tmp_path):
     assert res["new"] == 2 and res["p0"] == 1   # 清潔被排除
 
 
-def test_run_second_pass_no_new(tmp_path):
+def test_run_second_pass_no_new(tmp_path, monkeypatch):
+    # dry-run 現為唯讀不持久化 → 用真跑（mock 送達成功）驗水位去重
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True, "reason": "ok"})
     csvp = tmp_path / "w.csv"
     statep = tmp_path / "s.json"
     _write_csv(csvp, [_p0_row(i) for i in range(3)])
-    watcher.run(str(csvp), str(statep), dry_run=True)   # 第一輪
-    res = watcher.run(str(csvp), str(statep), dry_run=True)  # 第二輪同檔
+    watcher.run(str(csvp), str(statep), dry_run=False)   # 第一輪
+    res = watcher.run(str(csvp), str(statep), dry_run=False)  # 第二輪同檔
     assert res["new"] == 0 and res["pushed"] == 0
 
 
@@ -82,7 +84,8 @@ def test_cost_cap_triggers_alert_no_push(tmp_path, monkeypatch):
     statep = tmp_path / "s.json"
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     _write_csv(csvp, [_p0_row(i) for i in range(25)])  # 25 > cap 20
-    res = watcher.run(str(csvp), str(statep), dry_run=True, push_cap=20)
+    # 真跑（capped 路徑不呼叫 notify，不會推真 Slack）
+    res = watcher.run(str(csvp), str(statep), dry_run=False, push_cap=20)
     assert res["status"] == "capped"
     assert res["pushed"] == 0
     assert res["alert"] is not None
@@ -99,7 +102,7 @@ def test_cost_cap_alert_includes_blocked_list(tmp_path, monkeypatch):
     monkeypatch.setattr(watcher, "ALERT_DIR", str(tmp_path / "alerts"))
     rows = [_p0_row(i, title=f"圖書館資訊系統建置-{i}") for i in range(25)]
     _write_csv(csvp, rows)
-    res = watcher.run(str(csvp), str(statep), dry_run=True, push_cap=20)
+    res = watcher.run(str(csvp), str(statep), dry_run=False, push_cap=20)
     payload = json.loads(Path(res["alert"]).read_text(encoding="utf-8"))
     blocked = payload["blocked_p0"]
     # 全部 25 筆被擋的 P0 都要在清單裡，且帶可辨識欄位
@@ -137,11 +140,12 @@ def test_empty_key_same_content_still_deduped(tmp_path):
     assert len(new) == 1
 
 
-def test_runlog_written(tmp_path):
+def test_runlog_written(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "notify", lambda *a, **k: {"sent": True, "reason": "ok"})
     csvp = tmp_path / "w.csv"
     statep = tmp_path / "s.json"
     _write_csv(csvp, [_p0_row(i) for i in range(2)])
-    watcher.run(str(csvp), str(statep), dry_run=True)
+    watcher.run(str(csvp), str(statep), dry_run=False)
     st = json.loads(statep.read_text(encoding="utf-8"))
     assert len(st["runs"]) == 1
     run = st["runs"][0]


### PR DESCRIPTION
關閉盲點：#22 工項 1（新鮮度告警）+ 修「查詢窗對不上資料源固有 2 月延遲」的設計缺陷。換源（工項 3）暫不做。

## 根因翻轉（推翻本 PR 初稿前提）
- 官方政府電子採購網開放資料**天生延遲 ~2 個月**（官方頁逐字：「每月 5 號產出 2 月前資料」），以**半月批次檔**發布（`filename` = `tender_YYYYMM0H.xml`，末 2 碼 0H = 半月期別 01/02，非日）。`date` 是公告/截止日（可未來）、不是發布時點。
- 原 watcher 用「公告日最近 2 天」窗 → 對永遠落後 2 月的源**結構性抓不到**、天天 0 筆。原「公告日距今 14 天」新鮮度門檻 → 健康狀態資料本就 ~60 天舊、**天天誤報**。兩者皆作廢。

## 改動（方案 A：一切以批次 filename 為錨）
- **fetch_pcc**：COLS/OUT_FIELDS/map_row 帶 `filename`；新增 `--latest-batches N`（group_by filename 取最新 N 批 → 抓那幾批，取代 `--days` 公告日窗）；`query_rows` 支援 order_by/group_by。
- **freshness**：批次模型 `batch_key`/`batch_period`/`expected_latest_batch_period`/`check_batch_freshness`（+ `taipei_today`）。
- **watcher**：`find_new_by_batch`——state 記 `last_batch` 游標，只推「批次 > last_batch」的案；含**冷啟動基線**（不回補歷史 backlog）與**無 filename fallback**（退回 seen_keys 水位法，drill/舊資料相容）。新鮮度 `check_data_freshness` 改批次節奏。
- **slack_notify**：freshness payload 改「最新批次 / 預期批次 / 落後期數」。
- **workflows**：daily + weekly fetch 改 `--latest-batches 3`；watcher 用 `--freshness-grace`；保留 `concurrency`。

## 新鮮度判準
最新批次 vs「依官方節奏應有的最新批次」（今天 -2 月下半月，5 號前 -3 月），落後 > `grace`（預設 1 個半月期）→ 告警。容忍落後 1 期（正常時點差），落後 ≥2 期才報。
**實證 2026-06-29**：TwinkleAI 最新 `20260302`、預期 `20260402` → 落後 2 期 → 正當觸發（非誤報，mirror 確實缺 4 月）。

## 保留 PR #23 兩輪 codex 健壯性
節流只在 sent=True / dry-run 無副作用 / 壞 state 不 crash / 併發保護 / master 失敗不中斷 P0 / Asia-Taipei / webhook 邊界 / 髒值忽略——全沿用，改批次語意。

## 驗證
全套 **146 passed / 5 xfailed**。`tests/test_freshness.py` 重寫為批次模型（批次識別/節奏/新鮮度/新案偵測/冷啟動/fallback + 8 點健壯性回歸）、`tests/test_fetch_batches.py` 測批次抓取純函式。
⚠️ `--latest-batches` 對真 TwinkleAI 的抓取**待 CI 實測**（本機無 token、MCP 不可用）；協調者已用 MCP 確認 filename 欄存在、TwinkleAI `20260302`/官方 `20260402`。
⚠️ 過渡：merge 後到首次批次 fetch 前，master 仍無 filename 欄 → 新鮮度會報「找不到有效批次」（資料確實 stale，非假警，CI 跑完即正常）。

不自行 merge / 不推真 Slack。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
